### PR TITLE
107 examples break in sbi v022

### DIFF
--- a/examples/configs/infer/quijote_pydelfi_CMAF.yaml
+++ b/examples/configs/infer/quijote_pydelfi_CMAF.yaml
@@ -6,8 +6,8 @@ prior:
   module: 'ili.utils'
   class: 'Uniform'
   args:
-    lower: [0.1, 0.5, 0.6]
-    upper: [0.5, 0.9, 1.0]
+    low: [0.1, 0.5, 0.6]
+    high: [0.5, 0.9, 1.0]
 
 model:
   module: 'ili.inference.pydelfi_wrappers'

--- a/examples/configs/infer/quijote_pydelfi_CMAF.yaml
+++ b/examples/configs/infer/quijote_pydelfi_CMAF.yaml
@@ -3,7 +3,7 @@ n_params: 3
 n_data: 222
 
 prior:
-  module: 'pydelfi.priors'
+  module: 'ili.utils'
   class: 'Uniform'
   args:
     lower: [0.1, 0.5, 0.6]

--- a/examples/configs/infer/quijote_sbi_MAF.yaml
+++ b/examples/configs/infer/quijote_sbi_MAF.yaml
@@ -1,6 +1,6 @@
 
 prior:
-  module: 'sbi.utils'
+  module: 'ili.utils'
   class: 'BoxUniform'
   args:
     low: [0.1, 0.5, 0.6]

--- a/examples/configs/infer/quijote_sbi_MDN.yaml
+++ b/examples/configs/infer/quijote_sbi_MDN.yaml
@@ -1,6 +1,6 @@
 
 prior:
-  module: 'sbi.utils'
+  module: 'ili.utils'
   class: 'BoxUniform'
   args:
     low: [0.1, 0.5, 0.6]

--- a/examples/configs/infer/toy_pydelfi.yaml
+++ b/examples/configs/infer/toy_pydelfi.yaml
@@ -6,8 +6,8 @@ prior:
   module: 'ili.utils'
   class: 'Uniform'
   args:
-    lower: [0,0,0]
-    upper: [1,1,1]
+    low: [0,0,0]
+    high: [1,1,1]
 
 model:
   module: 'ili.inference.pydelfi_wrappers'

--- a/examples/configs/infer/toy_pydelfi.yaml
+++ b/examples/configs/infer/toy_pydelfi.yaml
@@ -3,7 +3,7 @@ n_params: 3
 n_data: 10
 
 prior:
-  module: 'pydelfi.priors'
+  module: 'ili.utils'
   class: 'Uniform'
   args:
     lower: [0,0,0]

--- a/examples/configs/infer/toy_sbi_SNLE.yaml
+++ b/examples/configs/infer/toy_sbi_SNLE.yaml
@@ -1,6 +1,6 @@
 
 prior:
-  module: 'sbi.utils'
+  module: 'ili.utils'
   class: 'BoxUniform'
   args:
     low: [0,0,0]

--- a/examples/configs/infer/toy_sbi_SNPE.yaml
+++ b/examples/configs/infer/toy_sbi_SNPE.yaml
@@ -1,7 +1,7 @@
 
 prior:
-  module: 'sbi.utils'
-  class: 'BoxUniform'
+  module: 'ili.utils'
+  class: 'Uniform'
   args:
     low: [0,0,0]
     high: [1,1,1]

--- a/examples/configs/infer/toy_sbi_SNRE.yaml
+++ b/examples/configs/infer/toy_sbi_SNRE.yaml
@@ -1,6 +1,6 @@
 
 prior:
-  module: 'sbi.utils'
+  module: 'ili.utils'
   class: 'BoxUniform'
   args:
     low: [0,0,0]

--- a/examples/configs/infer/toy_sbi_multiround.yaml
+++ b/examples/configs/infer/toy_sbi_multiround.yaml
@@ -1,6 +1,6 @@
 
 prior:
-  module: 'sbi.utils'
+  module: 'ili.utils'
   class: 'BoxUniform'
   args:
     low: [0,0,0]

--- a/ili/utils/__init__.py
+++ b/ili/utils/__init__.py
@@ -1,2 +1,3 @@
 from .import_utils import load_class, load_from_config
 from .dataset import Dataset
+from .distributions import Uniform

--- a/ili/utils/distributions.py
+++ b/ili/utils/distributions.py
@@ -1,0 +1,26 @@
+
+try:
+    import torch
+    from sbi.utils import BoxUniform as ModuleUniform
+    backend = 'sbi'
+except ModuleNotFoundError:
+    from pydelfi.priors import Uniform as ModuleUniform
+    backend = 'pydelfi'
+
+
+class Uniform(ModuleUniform):
+    """Wrapper for sbi and pydelfi uniform distributions
+    which allows to use the same code for both backends.
+    Takes the lower and upper bounds of the uniform distribution
+    over the parameters and provides logpdf and sample methods.
+
+    Args:
+        low (vector): lower bound of the uniform distribution
+        high (vector): upper bound of the uniform distribution
+    """
+
+    def __init__(self, low, high, device='cpu'):
+        if backend == 'sbi':
+            low = torch.tensor(low).to(device)
+            high = torch.tensor(high).to(device)
+        super().__init__(low, high)

--- a/notebooks/tutorial.ipynb
+++ b/notebooks/tutorial.ipynb
@@ -43,6 +43,7 @@
     "import torch.nn as nn\n",
     "import sbi\n",
     "\n",
+    "import ili\n",
     "from ili.dataloaders import NumpyLoader\n",
     "from ili.inference.runner_sbi import SBIRunner\n",
     "from ili.validation.metrics import PosteriorCoverage, PlotSinglePosterior\n",
@@ -144,7 +145,7 @@
    "outputs": [],
    "source": [
     "# define a prior\n",
-    "prior = sbi.utils.BoxUniform(low=(0,0,0), high=(1,1,1), device=device)\n",
+    "prior = ili.utils.Uniform(low=(0,0,0), high=(1,1,1), device=device)\n",
     "\n",
     "# define an inference class (here, we are doing amortized posterior inference)\n",
     "inference_class = sbi.inference.SNPE\n",
@@ -753,7 +754,7 @@
    "outputs": [],
    "source": [
     "# define a prior\n",
-    "prior = sbi.utils.BoxUniform(low=(0,0,0), high=(1,1,1), device=device)\n",
+    "prior = ili.utils.Uniform(low=(0,0,0), high=(1,1,1), device=device)\n",
     "\n",
     "# define an inference class (here, we are doing amortized likelihood inference)\n",
     "inference_class = sbi.inference.SNLE\n",
@@ -1264,7 +1265,7 @@
    "outputs": [],
    "source": [
     "# define a prior\n",
-    "prior = sbi.utils.BoxUniform(low=prior_min, high=prior_max, device=device)\n",
+    "prior = ili.utils.Uniform(low=prior_min, high=prior_max, device=device)\n",
     "\n",
     "# define an inference class (here, we are doing amortized posterior inference)\n",
     "inference_class = sbi.inference.SNPE\n",


### PR DESCRIPTION
Created a new `ili.utils.distributions` module which contains backend-agnostic distribution functions. In later iterations, it can be used to merge priors from `torch.distributions` and `pydelfi`.

Also updated any example which needs to call BoxUniform, to now call the wrapper in `ili.utils`