### PR TITLE
Fix prior configuration

### DIFF
--- a/ili/inference/runner_sbi.py
+++ b/ili/inference/runner_sbi.py
@@ -95,12 +95,13 @@ class SBIRunner:
         with open(config_path, "r") as fd:
             config = yaml.safe_load(fd)
 
-        # torch distributions only accept tensors
+        # load prior distribution
         for k, v in config["prior"]["args"].items():
+            # torch distributions only accept tensors
             config["prior"]["args"][k] = torch.Tensor(v).to(config["device"])
-
-        # load prior and proposal distributions
         prior = load_from_config(config["prior"])
+
+        # load proposal distributions
         proposal = None
         if "proposal" in config:
             for k, v in config["proposal"]["args"].items():

--- a/ili/inference/runner_sbi.py
+++ b/ili/inference/runner_sbi.py
@@ -95,13 +95,18 @@ class SBIRunner:
         with open(config_path, "r") as fd:
             config = yaml.safe_load(fd)
 
+        # torch distributions only accept tensors
+        for k, v in config["prior"]["args"].items():
+            config["prior"]["args"][k] = torch.Tensor(v).to(config["device"])
+
         # load prior and proposal distributions
-        config['prior']['args']['device'] = config['device']
         prior = load_from_config(config["prior"])
+        proposal = None
         if "proposal" in config:
+            for k, v in config["proposal"]["args"].items():
+                config["proposal"]["args"][k] = torch.Tensor(v).to(
+                    config["device"])
             proposal = load_from_config(config["proposal"])
-        else:
-            proposal = None
 
         # load embedding net
         if "embedding_net" in config:

--- a/ili/inference/runner_sbi.py
+++ b/ili/inference/runner_sbi.py
@@ -265,9 +265,14 @@ class SBIRunner:
             summaries.append(model.summary)
 
         # ensemble all trained models, weighted by validation loss
-        weights = torch.tensor(
+        val_logprob = torch.tensor(
             [float(x["best_validation_log_prob"][0]) for x in summaries]
         ).to(self.device)
+        # Subtract maximum loss to improve numerical stability of exp
+        # (cancels in next line)
+        weights = torch.exp(val_logprob - val_logprob.max())
+        weights /= weights.sum()
+
         posterior_ensemble = NeuralPosteriorEnsemble(
             posteriors=posteriors,
             weights=weights)  # raises warning due to bug in sbi

--- a/tests/test_sbi.py
+++ b/tests/test_sbi.py
@@ -45,7 +45,8 @@ def test_snpe(monkeypatch):
     loader = NumpyLoader(x=x, theta=theta)
 
     # define a prior
-    prior = sbi.utils.BoxUniform(low=(0, 0, 0), high=(1, 1, 1), device=device)
+    low, high = torch.zeros(3).to(device), torch.ones(3).to(device)
+    prior = sbi.utils.BoxUniform(low=low, high=high)
 
     # define an inference class (we are doing amortized posterior inference)
     inference_class = sbi.inference.SNPE
@@ -148,7 +149,8 @@ def test_snle(monkeypatch):
     loader = NumpyLoader(x=x, theta=theta)
 
     # define a prior
-    prior = sbi.utils.BoxUniform(low=(0, 0, 0), high=(1, 1, 1), device=device)
+    low, high = torch.zeros(3).to(device), torch.ones(3).to(device)
+    prior = sbi.utils.BoxUniform(low=low, high=high)
 
     # define an inference class (we are doing amortized likelihood inference)
     inference_class = sbi.inference.SNLE
@@ -236,7 +238,8 @@ def test_snre():
     loader = NumpyLoader(x=x, theta=theta)
 
     # define a prior
-    prior = sbi.utils.BoxUniform(low=(0, 0, 0), high=(1, 1, 1), device=device)
+    low, high = torch.zeros(3).to(device), torch.ones(3).to(device)
+    prior = sbi.utils.BoxUniform(low=low, high=high)
 
     # define an inference class (we are doing amortized likelihood inference)
     inference_class = sbi.inference.SNRE
@@ -308,7 +311,8 @@ def test_multiround():
     # train a model to infer x -> theta. save it as toy/posterior.pkl
 
     # define a prior
-    prior = sbi.utils.BoxUniform(low=(0, 0, 0), high=(1, 1, 1), device=device)
+    low, high = torch.zeros(3).to(device), torch.ones(3).to(device)
+    prior = sbi.utils.BoxUniform(low=low, high=high)
 
     # define an inference class (we are doing amortized posterior inference)
     inference_class = sbi.inference.SNPE_C
@@ -539,4 +543,3 @@ def test_yaml():
     ValidationRunner.from_config("./toy/val.yml")
 
     return
-

--- a/tests/test_sbi.py
+++ b/tests/test_sbi.py
@@ -381,11 +381,11 @@ def test_yaml():
 
     # Yaml file for infer - standard
     data = dict(
-        prior={'module': 'sbi.utils',
-               'class': 'BoxUniform',
+        prior={'module': 'torch.distributions',
+               'class': 'Normal',
                'args': dict(
-                   low=[0, 0, 0],
-                   high=[1, 1, 1],
+                   loc=[0.5, 0.5, 0.5],
+                   scale=[0.5, 0.5, 0.5],
                ),
                },
         model={'module':  'sbi.inference',


### PR DESCRIPTION
`sbi` v0.22 BoxUniform and `torch.distributions` require that all arguments be Tensors. This breaks our initialization of priors in the `sbi` backend, which was previously done with floats and tuples.

Now, we catch the `prior` arguments and convert them to Tensors on the right device before passing them to `SBIRunner`.

This will only break if the prior distribution accepts something other than a number (e.g. string). However, this isn't the case for any `torch.distributions`.