### PR TITLE
117 fix sbi sequential

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,5 +1,4 @@
-Configuration
----------------------------------
+# Configuration
 
 This document provides guidance to configuring an inference pipeline with ltu-ili and includes links and references to the various functionality options. There are three stages to the inference pipeline:
 - [**Data Loading**](#data-loading): Loading various structured data into memory
@@ -29,10 +28,10 @@ theta_file: 'theta.npy'
 ```bash
 # SummarizerDatasetLoader configuration
 
-data_dir: './ltu-ili-data/quijote'  # contains param_file and train_test_split file and a hierarchy of .nc data files
+in_dir: './ltu-ili-data/quijote'  # contains param_file and train_test_split file and a hierarchy of .nc data files
 
-data_root_file: 'tpcf/z_0.50/quijote'  # prefix to each .nc file
-param_file: 'latin_hypercube_params.txt' 
+x_root: 'tpcf/z_0.50/quijote'  # prefix to each .nc file
+theta_file: 'latin_hypercube_params.txt' 
 train_test_split_file: 'quijote_train_test_val.json'  # specifies which indices in param_file are in train/test/val
 
 param_names: ['Omega_m', 'h', 'sigma_8']
@@ -41,21 +40,21 @@ param_names: ['Omega_m', 'h', 'sigma_8']
 ```bash
 # SBISimulator configuration
 
-in_dir: './toy'  # where to load xobs_file and thetaobs_file from
-out_dir: './toy'  # where to save simulated data to
+in_dir: './toy'  # where to find initial data
 
-xobs_file: 'xobs.npy'  # test data
-thetaobs_file: 'thetaobs.npy'  # test parameters
+xobs_file: 'xobs.npy'  # the observed data around which to center simulations
+thetafid_file: 'thetafid.npy'  # only if true parameters are known
 
-x_file: 'x.npy'  # filename to save simulated data
-theta_file: 'theta.npy'  # filename to save simulation parameters
-num_simulations: 400  # how many simulations to generate for each training round
+x_file: 'x.npy'  # file name of the initial data
+theta_file: 'theta.npy'  # file name of the initial parameters
+num_simulations: 400  # number of simulations to generate per round
+save_simulated: False  # whether to concatenate the simulated data into x_file and theta_file
 ```
 
-You are also welcome to design your own dataloading objects, so long as they contain the functions: `__len__`, `get_all_data`, and `get_all_parameters`.
+You are also welcome to design your own dataloading objects. They will work with NPE/NLE/NRE models so long as they contain the functions: `__len__`, `get_all_data`, and `get_all_parameters`. For SNPE/SNLE/SNRE models, they must also contain the `simulate` and `get_obs_data` functions. See the [_BaseLoader](./ili/dataloaders/loaders.py#L20) template for more details.
 
 ## Training
-There are three available training engines in ltu-ili, SBIRunner and SBIRunnerSequential for `sbi` models, and PydelfiRunner for `pydelfi` models. Each of these engines can be configured from a `yaml`-like configuration file or from iPython initialization as in [tutorial.ipynb](notebooks/tutorial.ipynb).
+There are three available training engines in ltu-ili, SBIRunner and SBIRunnerSequential for `sbi` (PyTorch) models, and PydelfiRunner for `pydelfi` (Tensorflow) models. Each of these engines can be configured from a `yaml`-like configuration file or from iPython initialization as in [tutorial.ipynb](notebooks/tutorial.ipynb).
 
 ### SBIRunner
 Here's an example configuration for `SBIRunner`:

--- a/examples/configs/data/quijote_TPCF.yaml
+++ b/examples/configs/data/quijote_TPCF.yaml
@@ -1,7 +1,7 @@
-data_dir: './ltu-ili-data/quijote'
+in_dir: './ltu-ili-data/quijote'
 
-data_root_file: 'tpcf/z_0.50/quijote'
-param_file: 'latin_hypercube_params.txt'
+x_root: 'tpcf/z_0.50/quijote'
+theta_file: 'latin_hypercube_params.txt'
 train_test_split_file: 'quijote_train_test_val.json'
 
 param_names: ['Omega_m', 'h', 'sigma_8']

--- a/examples/configs/data/toy_multiround.yaml
+++ b/examples/configs/data/toy_multiround.yaml
@@ -1,9 +1,9 @@
 in_dir: './toy'  # where to find initial data
 
 xobs_file: 'xobs.npy'  # the observed data around which to center simulations
-thetafid_file: 'thetaobs.npy'  # only if true parameters are known
+thetafid_file: 'thetafid.npy'  # only if true parameters are known
 
 x_file: 'x.npy'  # file name of the initial data
 theta_file: 'theta.npy'  # file name of the initial parameters
 num_simulations: 400  # number of simulations to generate per round
-save_simulated: False  # whether to save the simulated data into x_file and theta_file
+save_simulated: False  # whether to concatenate the simulated data into x_file and theta_file

--- a/examples/configs/data/toy_multiround.yaml
+++ b/examples/configs/data/toy_multiround.yaml
@@ -1,9 +1,9 @@
 in_dir: './toy'  # where to find initial data
-out_dir: './toy'  # where to save new simulations
 
 xobs_file: 'xobs.npy'  # the observed data around which to center simulations
-thetaobs_file: 'thetaobs.npy'  # only if true parameters are known
+thetafid_file: 'thetaobs.npy'  # only if true parameters are known
 
 x_file: 'x.npy'  # file name of the initial data
 theta_file: 'theta.npy'  # file name of the initial parameters
 num_simulations: 400  # number of simulations to generate per round
+save_simulated: False  # whether to save the simulated data into x_file and theta_file

--- a/examples/configs/infer/toy_sbi_multiround.yaml
+++ b/examples/configs/infer/toy_sbi_multiround.yaml
@@ -15,16 +15,17 @@ model:
     - model: 'maf'  # Masked Autoregressive Flow
       hidden_features: 100 
       num_transforms: 2
-      signature: "maf_mr"
+      signature: "m1"
     - model: 'mdn'  # Mixture Density Network
       hidden_features: 50 
       num_components: 4
+      signature: "m2"
     
 # Specify the neural training hyperparameters
 train_args:
   training_batch_size: 32
   learning_rate: 0.001
-  num_round: 2  # number of rounds of simulations
+  num_round: 5  # number of rounds of simulations
 
 device: 'cpu'  # Run on CPU
 output_path: './toy'  # Where to save the posterior

--- a/examples/configs/val/toy_sbi_multiround.yaml
+++ b/examples/configs/val/toy_sbi_multiround.yaml
@@ -2,6 +2,7 @@ backend: 'sbi'
 
 posterior_path: './toy/toy_mr_posterior.pkl'
 output_path: './toy'
+style_path: './style.mcstyle'  # Optional matplotlib style file
 labels: ['t1', 't2', 't3']
 
 ensemble_mode: True
@@ -12,20 +13,4 @@ metrics:
     class: 'PlotSinglePosterior'
     args:
       num_samples: 1200
-      sample_method: 'direct'
-
-  coverages:
-    module: 'ili.validation.metrics'
-    class: 'PosteriorCoverage'
-    args:
-      num_samples: 100
-      sample_method: 'direct'
-      plot_list: ["coverage", "histogram", "predictions", "tarp"]
-
-
-  samples:
-    module: 'ili.validation.metrics'
-    class: 'PosteriorSamples'
-    args:
-      num_samples: 100
       sample_method: 'direct'

--- a/examples/toy_sbi_multiround.py
+++ b/examples/toy_sbi_multiround.py
@@ -6,9 +6,9 @@ from ili.validation.runner import ValidationRunner
 
 
 def simulator(params):
-    # create toy 'simulations'
+    # create toy simulations
     x = np.arange(10)
-    y = params @ np.array([np.sin(x), x ** 2, x])
+    y = params @ np.array([3*np.sin(x), x ** 2, -2*x])
     y += np.random.randn(len(params), len(x))
     return y
 

--- a/examples/toy_sbi_multiround.py
+++ b/examples/toy_sbi_multiround.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     # simulate a single test observation and save as numpy files
     theta0 = np.zeros((1, 3))+0.5
     x0 = simulator(theta0)
-    np.save('toy/thetaobs.npy', theta0[0])
+    np.save('toy/thetafid.npy', theta0[0])
     np.save('toy/xobs.npy', x0[0])
 
     # setup a dataloader which can simulate

--- a/ili/dataloaders/loaders.py
+++ b/ili/dataloaders/loaders.py
@@ -48,16 +48,30 @@ class NumpyLoader(_BaseLoader):
     """A class for loading in-memory data using numpy arrays.
 
     Args:
-        x (np.array): Array of data of shape (Ndata, \*data.shape)
-        theta (np.array): Array of parameters of shape (Ndata, \*theta.shape)
+        x (np.array): Array of training data of
+            shape (Ndata, \*data.shape)
+        theta (np.array): Array of training parameters of
+            shape (Ndata, \*parameters.shape)
+        xobs (Optional[np.array]): Array of observed data of
+            shape (\*data.shape). Defaults to None.
+        thetafid (Optional[np.array]): Array of fiducial
+            parameters of shape (\*parameters.shape). Defaults to None.
     """
 
-    def __init__(self, x, theta) -> None:
+    def __init__(
+        self,
+        x: np.array,
+        theta: np.array,
+        xobs: Optional[np.array] = None,
+        thetafid: Optional[np.array] = None
+    ) -> None:
         self.x = x
         self.theta = theta
         if len(self.x) != len(self.theta):
             raise Exception(
                 "Stored data and parameters are not of same length.")
+        self.xobs = xobs
+        self.thetafid = thetafid
 
     def __len__(self) -> int:
         """Returns the total number of data points in the dataset
@@ -68,7 +82,7 @@ class NumpyLoader(_BaseLoader):
         return len(self.x)
 
     def get_all_data(self) -> np.array:
-        """Returns all the loaded data
+        """Returns all the loaded data for training
 
         Returns:
             np.array: data
@@ -76,12 +90,29 @@ class NumpyLoader(_BaseLoader):
         return self.x
 
     def get_all_parameters(self):
-        """Returns all the loaded parameters
+        """Returns all the loaded parameters for training
 
         Returns:
             np.array: parameters
         """
         return self.theta
+
+    def get_obs_data(self) -> np.array:
+        """Returns the observed data
+
+        Returns:
+            np.array: data
+        """
+        return self.xobs
+
+    def get_fid_parameters(self):
+        """Returns the fiducial parameters which we expect the
+        observed data to resemble
+
+        Returns:
+            np.array: parameters
+        """
+        return self.thetafid
 
 
 class StaticNumpyLoader(NumpyLoader):
@@ -89,19 +120,41 @@ class StaticNumpyLoader(NumpyLoader):
 
     Args:
         in_dir (str): path to the location of stored data
-        x_file (str): filename of the stored data
-        theta_file (str): filename of the stored parameters
+        x_file (str): filename of the stored training data
+        theta_file (str): filename of the stored training parameters
+        xobs_file (Optional[str]): filename used for observed x values
+        thetafid_file (Optional[str]): filename used for fiducial parameters
     """
 
-    def __init__(self, in_dir: str, x_file: str, theta_file: str):
+    def __init__(
+        self,
+        in_dir: str,
+        x_file: str,
+        theta_file: str,
+        xobs_file: Optional[str] = None,
+        thetafid_file: Optional[str] = None
+    ) -> None:
         self.in_dir = Path(in_dir)
         self.x_path = self.in_dir / x_file
         self.theta_path = self.in_dir / theta_file
 
+        # Load stored data (if specified)
         x = np.load(self.x_path)
         theta = np.load(self.theta_path)
+        if xobs_file is None:
+            self.xobs_path = None
+            xobs = None
+        else:
+            self.xobs_path = self.in_dir / xobs_file
+            xobs = np.load(self.xobs_path)
+        if thetafid_file is None:
+            self.thetafid_path = None
+            thetafid = None
+        else:
+            self.thetafid_path = self.in_dir / thetafid_file
+            thetafid = np.load(self.thetafid_path)
 
-        super().__init__(x=x, theta=theta)
+        super().__init__(x=x, theta=theta, xobs=xobs, thetafid=thetafid)
 
 
 class SummarizerDatasetLoader(_BaseLoader):
@@ -211,7 +264,7 @@ class SummarizerDatasetLoader(_BaseLoader):
         return theta[param_names].values
 
 
-class SBISimulator(_BaseLoader):
+class SBISimulator(NumpyLoader):
     """
     Class to run simulations of data and parameters and save
     results to numpy files. Only works for sbi backend.
@@ -219,40 +272,68 @@ class SBISimulator(_BaseLoader):
     Args:
         in_dir (str): path to the location of stored data
         xobs_file (str): filename used for observed x values
-        thetaobs_file (str): filename used for observed parameters
-        out_dir (str): path to the location where to save  data
-        x_file (str): filename to use to store data
-        theta_file (str): filename to use to store parameters
         num_simulations (int): number of simulations to run at each call
         simulator (callable): function taking the parameters as an
             argument and returns data
+        save_simulated (Optional[bool]): whether to save simulated data.
+            Concatenates to previous data if True. Defaults to False.
+        x_file (Optional[str]): filename of the stored first-round
+            training data
+        theta_file (Optional[str]): filename of the stored first-round
+            training parameters
+        thetafid_file (Optional[str]): filename used for fiducial parameters
     """
 
     def __init__(
-            self,
-            in_dir: str,
-            xobs_file: str,
-            thetaobs_file: str,
-            out_dir: str,
-            x_file: str,
-            theta_file: str,
-            num_simulations: int,
-            simulator: Optional[callable] = None,
+        self,
+        in_dir: str,
+        xobs_file: str,
+        num_simulations: int,
+        simulator: Optional[callable] = None,
+        save_simulated: Optional[bool] = False,
+        x_file: Optional[str] = None,
+        theta_file: Optional[str] = None,
+        thetafid_file: Optional[str] = None,
     ):
         self.in_dir = Path(in_dir)
         self.xobs_path = self.in_dir / xobs_file
-        self.thetaobs_path = self.in_dir / thetaobs_file
-        self.out_dir = Path(out_dir)
-        self.x_path = self.out_dir / x_file
-        self.theta_path = self.out_dir / theta_file
         self.num_simulations = num_simulations
         self.simulator = simulator
+        self.save_simulated = save_simulated
 
-        self.xobs = np.load(self.xobs_path)
-        self.thetaobs = np.load(self.thetaobs_path)
+        # If save_simulated, check that x_file and theta_file are specified
+        if save_simulated and (x_file is None or theta_file is None):
+            raise Exception(
+                "If save_simulated is True, x_file and theta_file must be "
+                "specified."
+            )
 
-        self.theta = None
-        self.x = None
+        # Load stored data (if specified)
+        xobs = np.load(self.xobs_path)
+        x = None
+        theta = None
+        thetafid = None
+        if x_file is None:
+            self.x_path = None
+        else:
+            self.x_path = self.in_dir / x_file
+            if self.x_path.exists():
+                x = np.load(self.x_path)
+        if theta_file is None:
+            self.theta_path = None
+        else:
+            self.theta_path = self.in_dir / theta_file
+            if self.theta_path.exists():
+                theta = np.load(self.theta_path)
+        if thetafid_file is None:
+            self.thetafid_path = None
+        else:
+            self.thetafid_path = self.in_dir / thetafid_file
+            thetafid = np.load(self.thetafid_path)
+
+        super().__init__(
+            x=x, theta=theta, xobs=xobs, thetafid=thetafid
+        )
 
     def __len__(self) -> int:
         """Returns the total number of data points produced when called
@@ -285,46 +366,18 @@ class SBISimulator(_BaseLoader):
         theta = proposal.sample((self.num_simulations,)).cpu()
         x = simulate_in_batches(self.simulator, theta)
         theta, x = theta.numpy(), x.numpy()
+
+        # Save simulated data (concatenates to previous data)
         if self.theta is None or self.x is None:
             self.theta, self.x = theta, x
         else:
             self.theta = np.concatenate((self.theta, theta))
             self.x = np.concatenate((self.x, x))
-        np.save(self.theta_path, self.theta)
-        np.save(self.x_path, self.x)
+        if self.save_simulated:
+            np.save(self.theta_path, self.theta)
+            np.save(self.x_path, self.x)
+
         return theta, x
-
-    def get_obs_data(self) -> np.array:
-        """Returns the observed data
-
-        Returns:
-            np.array: data
-        """
-        return self.xobs
-
-    def get_obs_parameters(self):
-        """Returns the observed parameters
-
-        Returns:
-            np.array: parameters
-        """
-        return self.thetaobs
-
-    def get_all_data(self) -> np.array:
-        """Returns all the loaded data
-
-        Returns:
-            np.array: data
-        """
-        return self.x
-
-    def get_all_parameters(self):
-        """Returns all the loaded parameters
-
-        Returns:
-            np.array: parameters
-        """
-        return self.theta
 
 
 # TODO: Add loaders which load dynamically from many files, so

--- a/ili/inference/runner_sbi.py
+++ b/ili/inference/runner_sbi.py
@@ -350,25 +350,23 @@ class SBIRunnerSequential(SBIRunner):
 
         # load observed and pre-run data
         x_obs = loader.get_obs_data()
-        x = loader.get_all_data()  # None by default
-        theta = loader.get_all_parameters()  # None by default
 
         # pre-run data
-        if (x is not None) and (theta is not None):
+        if len(loader) > 0:
             logging.info(
                 "The first round of inference will use existing sims from the "
                 "loader. Make sure that the simulations were run from the "
                 "given proposal distribution for consistency.")
-            x = torch.Tensor(x).to(self.device)
-            theta = torch.Tensor(theta).to(self.device)
+            x = torch.Tensor(loader.get_all_data()).to(self.device)
+            theta = torch.Tensor(loader.get_all_parameters()).to(self.device)
         # no pre-run data
         else:
             logging.info(
                 "The first round of inference will simulate from the given "
                 "proposal or prior.")
             theta, x = loader.simulate(self.proposal)
-            theta, x = torch.Tensor(theta).to(
-                self.device), torch.Tensor(x).to(self.device)
+            x = torch.Tensor(x).to(self.device)
+            theta = torch.Tensor(theta).to(self.device)
 
         # instantiate embedding_net architecture, if necessary
         if self.embedding_net and hasattr(self.embedding_net, 'initalize_model'):

--- a/ili/inference/runner_sbi.py
+++ b/ili/inference/runner_sbi.py
@@ -91,7 +91,10 @@ class SBIRunner(_BaseRunner):
             device=device,
             name=name,
         )
-        self.proposal = proposal
+        if proposal is None:
+            self.proposal = prior
+        else:
+            self.proposal = proposal
         self.nets = nets
         self.embedding_net = embedding_net
         self.train_args = train_args
@@ -294,10 +297,6 @@ class SBIRunner(_BaseRunner):
         if seed is not None:
             torch.manual_seed(seed)
 
-        # instantiate embedding_net architecture, if necessary
-        if self.embedding_net and hasattr(self.embedding_net, 'initalize_model'):
-            self.embedding_net.initalize_model(n_input=x.shape[-1])
-
         # setup training engines for each model in the ensemble
         logging.info(f"MODEL INFERENCE CLASS: {self.class_name}")
         models = [self._setup_engine(net) for net in self.nets]
@@ -305,6 +304,10 @@ class SBIRunner(_BaseRunner):
         # load single-round data
         x = torch.Tensor(loader.get_all_data()).to(self.device)
         theta = torch.Tensor(loader.get_all_parameters()).to(self.device)
+
+        # instantiate embedding_net architecture, if necessary
+        if self.embedding_net and hasattr(self.embedding_net, 'initalize_model'):
+            self.embedding_net.initalize_model(n_input=x.shape[-1])
 
         # train a single round of inference
         t0 = time.time()
@@ -329,100 +332,69 @@ class SBIRunnerSequential(SBIRunner):
     multiple rounds
     """
 
-    def __call__(self, loader: _BaseLoader):
+    def __call__(self, loader: _BaseLoader, seed: int = None):
         """Train your posterior and save it to file
 
         Args:
             loader (_BaseLoader): data loader with ability to simulate
                 data-parameter pairs
         """
-        t0 = time.time()
+
+        # set seed for reproducibility
+        if seed is not None:
+            torch.manual_seed(seed)
+
+        # setup training engines for each model in the ensemble
+        logging.info(f"MODEL INFERENCE CLASS: {self.class_name}")
+        models = [self._setup_engine(net) for net in self.nets]
+
+        # load observed and pre-run data
         x_obs = loader.get_obs_data()
+        x = loader.get_all_data()  # None by default
+        theta = loader.get_all_parameters()  # None by default
 
-        all_model = []
-        for n, posterior in enumerate(self.nets):
-            all_model.append(self.inference_class(
-                prior=self.prior,
-                density_estimator=posterior,
-                device=self.device,
-            ))
-        proposal = self.prior
-
-        # loader has x and theta attributes, both default values are None
-        # Even in multiround inference, we can take advantage of prerun
-        # simulation-parameter pairs
-        x = loader.get_all_data()
-        theta = loader.get_all_parameters()
-        if x is not None and theta is not None:
-            theta = torch.Tensor(theta).to(self.device)
-            x = torch.Tensor(x).to(self.device)
-            prerun_sims = True
+        # pre-run data
+        if (x is not None) and (theta is not None):
             logging.info(
                 "The first round of inference will use existing sims from the "
                 "loader. Make sure that the simulations were run from the "
-                "given prior for consistency.")
+                "given proposal distribution for consistency.")
+            x = torch.Tensor(x).to(self.device)
+            theta = torch.Tensor(theta).to(self.device)
+        # no pre-run data
         else:
-            prerun_sims = False
             logging.info(
-                "The first round of inference will simulate from the given prior."
-            )
+                "The first round of inference will simulate from the given "
+                "proposal or prior.")
+            theta, x = loader.simulate(self.proposal)
+            theta, x = torch.Tensor(theta).to(
+                self.device), torch.Tensor(x).to(self.device)
 
-        # Start multiround inference
+        # instantiate embedding_net architecture, if necessary
+        if self.embedding_net and hasattr(self.embedding_net, 'initalize_model'):
+            self.embedding_net.initalize_model(n_input=x.shape[-1])
+
+        # train multiple rounds of inference
+        t0 = time.time()
         for rnd in range(self.num_rounds):
-            t1 = time.time()
-            logging.info(
-                f"Running round {rnd+1} of {self.num_rounds}"
+            logging.info(f"Running round {rnd+1} / {self.num_rounds}")
+
+            # train a round of inference
+            posterior_ensemble, summaries = self._train_round(
+                models=models,
+                x=x,
+                theta=theta,
+                proposal=self.proposal,
             )
 
-            if rnd == 0 and prerun_sims:
-                pass  # in that case theta and x were set before the loop on rnd
-            else:
-                theta, x = loader.simulate(proposal)
-                theta, x = torch.Tensor(theta).to(
-                    self.device), torch.Tensor(x).to(self.device)
+            # update proposal for next round
+            self.proposal = posterior_ensemble.set_default_x(x_obs)
+        logging.info(f"It took {time.time() - t0} seconds to train models.")
 
-            posteriors, val_logprob = [], []
-            for i in range(len(self.nets)):
-                logging.info(
-                    f"Training model {n+1} out of "
-                    f"{len(self.nets)} ensemble models"
-                )
-                if not isinstance(self.embedding_net, nn.Identity):
-                    self.embedding_net.initalize_model(n_input=x.shape[-1])
-                density_estimator = \
-                    all_model[i].append_simulations(theta, x, proposal).train(
-                        **self.train_args,
-                    )
-                posteriors.append(
-                    all_model[i].build_posterior(density_estimator))
-                val_logprob.append(
-                    all_model[i].summary["best_validation_log_prob"][-1])
+        if self.output_path is not None:
+            self._save_models(posterior_ensemble, summaries)
 
-            val_logprob = torch.tensor([float(vl) for vl in val_logprob])
-            # Subtract maximum loss to improve numerical stability of exp
-            # (cancels in next line)
-            val_logprob = torch.exp(val_logprob - val_logprob.max())
-            val_logprob /= val_logprob.sum()
-
-            posterior_ensemble = NeuralPosteriorEnsemble(
-                posteriors=posteriors,
-                weights=val_logprob)  # raises warning due to bug in sbi
-            posterior_ensemble.signatures = self.signatures
-
-            logging.info(f"Network signatures: {self.signatures}")
-
-            str_p = self.name + f"posterior_{rnd}.pkl"
-            with open(self.output_path / str_p, "wb") as f:
-                pickle.dump(posterior_ensemble, f)
-            proposal = posterior_ensemble.set_default_x(x_obs)
-            logging.info(
-                f"It took {time.time()-t1} seconds to complete round {rnd+1}.")
-
-        str_p = self.name + "posterior.pkl"
-        with open(self.output_path / str_p, "wb") as f:
-            pickle.dump(posterior_ensemble, f)
-        logging.info(
-            f"It took {time.time() - t0} seconds to train all models.")
+        return posterior_ensemble, summaries
 
 
 class ABCRunner(_BaseRunner):

--- a/ili/inference/runner_sbi.py
+++ b/ili/inference/runner_sbi.py
@@ -457,8 +457,6 @@ class ABCRunner(_BaseRunner):
         )
         samples = model(x_obs, return_summary=False, **self.train_args)
 
-        # save model
-
         # save if output path is specified
         if self.output_path is not None:
             str_p = self.name + "samples.pkl"

--- a/ili/validation/metrics.py
+++ b/ili/validation/metrics.py
@@ -113,6 +113,8 @@ class _SampleBasedMetric(_BaseMetric):
                            **self.sample_params)
 
 
+# Metrics evaluated at a single data point (use x_obs and theta_fid)
+
 class PlotSinglePosterior(_SampleBasedMetric):
     """Perform inference sampling on a single test point and plot the
     posterior in a corner plot.
@@ -136,7 +138,7 @@ class PlotSinglePosterior(_SampleBasedMetric):
         x: np.array,
         theta: np.array,
         x_obs: Optional[np.array] = None,
-        theta_obs: Optional[np.array] = None,
+        theta_fid: Optional[np.array] = None,
         signature: Optional[str] = ""
     ):
         """Given a posterior and test data, plot the inferred posterior of a
@@ -147,18 +149,18 @@ class PlotSinglePosterior(_SampleBasedMetric):
             x (np.array): tensor of test data
             theta (np.array): tensor of test parameters
             x_obs (np.array, optional): tensor of observed data
-            theta_obs (np.array, optional): tensor of true parameters for x_obs
+            theta_fid (np.array, optional): tensor of fiducial parameters for x_obs
             signature (str, optional): signature for the output file name
         """
         ndim = theta.shape[-1]
 
         # choose a random test datapoint if not supplied
-        if x_obs is None or theta_obs is None:
+        if x_obs is None:
             if self.seed:
                 np.random.seed(self.seed)
             ind = np.random.choice(len(x))
             x_obs = x[ind]
-            theta_obs = theta[ind]
+            theta_fid = theta[ind]
 
         # sample from the posterior
         sampler = self._build_sampler(posterior)
@@ -173,14 +175,15 @@ class PlotSinglePosterior(_SampleBasedMetric):
         )
         fig.map_lower(sns.kdeplot, levels=4, color=".2")
 
-        for i in range(ndim):
-            for j in range(i + 1):
-                if i == j:
-                    fig.axes[i, i].axvline(theta_obs[i], color="r")
-                else:
-                    fig.axes[i, j].axhline(theta_obs[i], color="r")
-                    fig.axes[i, j].axvline(theta_obs[j], color="r")
-                    fig.axes[i, j].plot(theta_obs[j], theta_obs[i], "ro")
+        if theta_fid is not None:  # do not plot fiducial parameters if None
+            for i in range(ndim):
+                for j in range(i + 1):
+                    if i == j:
+                        fig.axes[i, i].axvline(theta_fid[i], color="r")
+                    else:
+                        fig.axes[i, j].axhline(theta_fid[i], color="r")
+                        fig.axes[i, j].axvline(theta_fid[j], color="r")
+                        fig.axes[i, j].plot(theta_fid[j], theta_fid[i], "ro")
 
         # save
         if self.output_path is None:
@@ -197,6 +200,8 @@ class PlotSinglePosterior(_SampleBasedMetric):
 
         return fig
 
+
+# Metrics evaluated over a whole test set (use x and theta)
 
 class PosteriorSamples(_SampleBasedMetric):
     """
@@ -245,7 +250,7 @@ class PosteriorSamples(_SampleBasedMetric):
         signature: Optional[str] = "",
         # here for debugging purpose, otherwise error in runner.py line 123
         x_obs: Optional[np.array] = None,
-        theta_obs: Optional[np.array] = None
+        theta_fid: Optional[np.array] = None
     ):
         """Given a posterior and test data, infer posterior samples of a
         test dataset and save to file.
@@ -255,7 +260,7 @@ class PosteriorSamples(_SampleBasedMetric):
             x (np.array): tensor of test data
             theta (np.array): tensor of test parameters
             x_obs (np.array, optional): tensor of observed data
-            theta_obs (np.array, optional): tensor of true parameters for x_obs
+            theta_fid (np.array, optional): tensor of fiducial parameters for x_obs
         """
         # Sample the full dataset
         posterior_samples = self._sample_dataset(posterior, x)
@@ -577,7 +582,7 @@ class PosteriorCoverage(PosteriorSamples):
         x: np.array,
         theta: np.array,
         x_obs: Optional[np.array] = None,
-        theta_obs: Optional[np.array] = None,
+        theta_fid: Optional[np.array] = None,
         signature: Optional[str] = "",
         plot_list: Optional[list] = ["coverage", "histogram",
                                      "predictions", "tarp",
@@ -597,7 +602,7 @@ class PosteriorCoverage(PosteriorSamples):
             x (np.array): tensor of test data
             theta (np.array): tensor of test parameters
             x_obs (np.array, optional): Not used
-            theta_obs (np.array, optional): Not used
+            theta_fid (np.array, optional): Not used
             signature (str, optional): signature for the output file name
             plot_list (list, optional): list of plot types to save
 

--- a/ili/validation/runner.py
+++ b/ili/validation/runner.py
@@ -145,9 +145,8 @@ class ValidationRunner:
         # load data
         x_test = loader.get_all_data()
         theta_test = loader.get_all_parameters()
-        if hasattr(loader, 'simulate'):
-            x_obs = loader.get_obs_data()
-            theta_fid = loader.get_fid_parameters()
+        x_obs = loader.get_obs_data()
+        theta_fid = loader.get_fid_parameters()
 
         if ((not self.ensemble_mode) and (self.backend == 'sbi') and
                 isinstance(self.posterior, NeuralPosteriorEnsemble)):

--- a/ili/validation/runner.py
+++ b/ili/validation/runner.py
@@ -9,6 +9,7 @@ import yaml
 import matplotlib as mpl
 from pathlib import Path
 from typing import List, Optional
+from ili.dataloaders import _BaseLoader
 from ili.validation.metrics import _BaseMetric
 from ili.utils import load_from_config
 
@@ -128,16 +129,11 @@ class ValidationRunner:
             posterior.name = ''
         return posterior
 
-    def __call__(
-            self,
-            loader,
-            x_obs=None,
-            theta_obs=None
-    ):
+    def __call__(self, loader: _BaseLoader):
         """Run your validation metrics and save them to file
 
         Args:
-            loader (BaseLoader): data loader with stored data-parameter
+            loader (_BaseLoader): data loader with stored data-parameter
                 pairs or has ability to simulate data-parameter pairs
         """
         t0 = time.time()
@@ -145,9 +141,12 @@ class ValidationRunner:
         # load data
         x_test = loader.get_all_data()
         theta_test = loader.get_all_parameters()
+
+        # load observations for inference (defaults to None)
         x_obs = loader.get_obs_data()
         theta_fid = loader.get_fid_parameters()
 
+        # evaluate metrics on each posterior in the ensemble separately
         if ((not self.ensemble_mode) and (self.backend == 'sbi') and
                 isinstance(self.posterior, NeuralPosteriorEnsemble)):
             n = 0
@@ -158,13 +157,14 @@ class ValidationRunner:
                     logging.info(
                         f"Running metric {metric.__class__.__name__}.")
                     metric(posterior_model, x_test, theta_test, x_obs=x_obs,
-                           theta_obs=theta_fid, signature=signature)
+                           theta_fid=theta_fid, signature=signature)
+        # evaluate metrics on the ensemble posterior
         else:
             # evaluate metrics
             signature = self.name+"".join(self.signatures)
             for metric in self.metrics.values():
                 logging.info(f"Running metric {metric.__class__.__name__}.")
                 metric(self.posterior, x_test, theta_test,
-                       x_obs=x_obs, theta_obs=theta_obs, signature=signature)
+                       x_obs=x_obs, theta_fid=theta_fid, signature=signature)
 
         logging.info(f"It took {time.time() - t0} seconds to run all metrics.")

--- a/ili/validation/runner.py
+++ b/ili/validation/runner.py
@@ -147,7 +147,7 @@ class ValidationRunner:
         theta_test = loader.get_all_parameters()
         if hasattr(loader, 'simulate'):
             x_obs = loader.get_obs_data()
-            theta_obs = loader.get_obs_parameters()
+            theta_fid = loader.get_fid_parameters()
 
         if ((not self.ensemble_mode) and (self.backend == 'sbi') and
                 isinstance(self.posterior, NeuralPosteriorEnsemble)):
@@ -159,7 +159,7 @@ class ValidationRunner:
                     logging.info(
                         f"Running metric {metric.__class__.__name__}.")
                     metric(posterior_model, x_test, theta_test, x_obs=x_obs,
-                           theta_obs=theta_obs, signature=signature)
+                           theta_obs=theta_fid, signature=signature)
         else:
             # evaluate metrics
             signature = self.name+"".join(self.signatures)

--- a/tests/test_sbi.py
+++ b/tests/test_sbi.py
@@ -111,7 +111,7 @@ def test_snpe(monkeypatch):
     )
     fig = metric(
         posterior=posterior,
-        x_obs=x[ind], theta_obs=theta[ind],
+        x_obs=x[ind], theta_fid=theta[ind],
         x=x, theta=theta
     )
 
@@ -124,7 +124,7 @@ def test_snpe(monkeypatch):
     )
     fig = metric(
         posterior=posterior,
-        x_obs=x[ind], theta_obs=theta[ind],
+        x_obs=x[ind], theta_fid=theta[ind],
         x=x, theta=theta
     )
 
@@ -215,7 +215,7 @@ def test_snle(monkeypatch):
     )
     fig = metric(
         posterior=posterior,
-        x_obs=x[ind], theta_obs=theta[ind],
+        x_obs=x[ind], theta_fid=theta[ind],
         x=x, theta=theta
     )
 
@@ -228,7 +228,7 @@ def test_snle(monkeypatch):
     )
     fig = metric(
         posterior=posterior,
-        x_obs=x[ind], theta_obs=theta[ind],
+        x_obs=x[ind], theta_fid=theta[ind],
         x=x, theta=theta
     )
 
@@ -312,15 +312,16 @@ def test_multiround():
     np.save('toy/xobs.npy', x0[0])
 
     # setup a dataloader which can simulate
-    all_loader = SBISimulator('./toy',
-                              'xobs.npy',
-                              'thetaobs.npy',
-                              './toy',
-                              'x.npy',
-                              'theta.npy',
-                              400,
-                              simulator,
-                              )
+    all_loader = SBISimulator(
+        in_dir='./toy',
+        xobs_file='xobs.npy',
+        thetafid_file='thetaobs.npy',
+        x_file='x.npy',
+        theta_file='theta.npy',
+        num_simulations=400,
+        simulator=simulator,
+        save_simulated=True
+    )
 
     # train an SBI sequential model to infer x -> theta
 
@@ -498,9 +499,8 @@ def test_yaml():
     # Yaml file for data - multiround
     data = dict(
         in_dir='./toy',
-        out_dir='./toy',
         xobs_file='xobs.npy',
-        thetaobs_file='thetaobs.npy',
+        thetafid_file='thetaobs.npy',
         x_file='x.npy',
         theta_file='theta.npy',
         num_simulations=400,
@@ -570,8 +570,8 @@ def test_yaml():
     )
     with open('./toy/infer_multi.yml', 'w') as outfile:
         yaml.dump(data, outfile, default_flow_style=False)
-        
-    # Yaml file for infer - ABC
+
+    #  Yaml file for infer - ABC
     data = dict(
         prior={'module': 'ili.utils',
                'class': 'Uniform',
@@ -584,7 +584,7 @@ def test_yaml():
                'class': 'MCABC',
                'name': 'toy_abc',
                'num_workers': 8,
-              },
+               },
         train_args=dict(
             num_simulations=1000000,
             quantile=0.01,
@@ -689,10 +689,10 @@ def test_yaml():
     loader.set_simulator(simulator)
     run_seq = SBIRunnerSequential.from_config("./toy/infer_multi.yml")
     run_seq(loader=loader)
-    
+
     # -------
     # Run for ABC
-    
+
     ABCRunner.from_config("./toy/infer_abc.yml")
 
     # -------


### PR DESCRIPTION
This PR addresses a number of issues regarding the outdated code for the SBIRunnerSequential class and in loaders.py. Changes include:

- Refactor SBIRunner and SBIRunnerSequential (#117)
  - In SBIRunner, `_setup_SNPE/SNLE/SNRE` have been absorbed into a simpler function `_setup_engine`.
  - In SBIRunner, some functionality within `__call__` has been refactored into the helper functions `_train_round` and `_save_models` so that it can be cleaner and reused in SBIRunnerSequential
  - `__call__` in SBIRunnerSequential has been redefined in terms of the new `_train_round` in SBIRunner.

- Improved consistency of dataloaders
  - `_BaseLoader` now has abstractmethod definitions to provide a template for creating new dataloders.
  - Every dataloader now has `xobs` and `thetafid` attributes and associated `get_obs_data` and `get_fid_parameters` functions. These default to `None` if not specified. Now, when `PlotSinglePosterior` is called in validation, it can check all loaders for a preconfigured observed data point without throwing an error. The naming of `theta_fid` solves #114.
  - The SummarizerDatasetLoader was nearly deprecated and had an entirely different parameterization than the other dataloaders. This object now inherits from NumpyLoader and its initialization has been made more similar to other loaders. Also, it has been moved to the end of loaders.py
  - SBISimulator's `simulate` function used to only simulate from scratch and always overwrite `x_file` and `theta_file` with its new simulations. Now, it can load pre-simulated data from `x_file` and `theta_file` and use it in the first-round inference. Then, with the new `save_simulated` bool, users have the options to concatenate newly simulated data to `x_file` and `theta_file`.

- Improved metrics.py usage of `xobs`.
  - `theta_obs` has been changed to `theta_fid` in all of its references. (#114)
  - Now in `PlotSinglePosterior`, if `theta_fid` is not specified, we don't plot the red 'truth' bars.
  - Added comments to define metrics which only do inference on one point vs those which do inference on the whole test set.

- Additional changes
  - the simulator in toy_sbi_multiround.py was slightly different than that of toy_sbi.py, so it has been made consistent.

Further tests can be added once PR #121 is merged.