### PR TITLE
removing the torch<2.0 requirement in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     xarray
 
     # pytorch backend
-    torch<2.0;python_version>='3.7'
+    torch;python_version>='3.7'
     sbi;python_version>='3.7'
     lampe;python_version>='3.7'
     tarp>=0.1.1;python_version>='3.7'


### PR DESCRIPTION
`sbi` now works natively with `torch`>=2.0. Also, the `torch<2` restriction seems to break installations on some Mac machines. So, this PR removes the restriction.