### PR TITLE
Add TARP tests for pydelfi

### DIFF
--- a/ili/validation/metrics.py
+++ b/ili/validation/metrics.py
@@ -643,8 +643,6 @@ class PosteriorCoverage(PosteriorSamples):
                 posterior_samples, theta, signature))
         if "logprob" in self.plot_list:
             self._calc_true_logprob(posterior_samples, theta, signature)
-
-        # Specifically for TARP
         if "tarp" in self.plot_list:
             figs.append(self._plot_TARP(posterior_samples, theta, signature,
                                         references=references, metric=metric,

--- a/ili/validation/metrics.py
+++ b/ili/validation/metrics.py
@@ -12,6 +12,7 @@ from abc import ABC
 from pathlib import Path
 from scipy.stats import gaussian_kde
 import logging
+import tarp
 from ili.utils.samplers import (EmceeSampler, PyroSampler,
                                 DirectSampler, VISampler)
 
@@ -21,7 +22,6 @@ try:
     from sbi.utils.posterior_ensemble import NeuralPosteriorEnsemble
     from ili.utils.ndes_pt import LampeNPE, LampeEnsemble
     ModelClass = NeuralPosterior
-    import tarp  # doesn't yet work with pydelfi/python 3.6
     backend = 'torch'
 except ModuleNotFoundError:
     from ili.inference.pydelfi_wrappers import DelfiWrapper
@@ -646,11 +646,6 @@ class PosteriorCoverage(PosteriorSamples):
 
         # Specifically for TARP
         if "tarp" in self.plot_list:
-            # check if if backend is sbi
-            global backend
-            if backend != 'torch':
-                raise NotImplementedError(
-                    'TARP is not yet supported by pydelfi backend')
             figs.append(self._plot_TARP(posterior_samples, theta, signature,
                                         references=references, metric=metric,
                                         num_alpha_bins=num_alpha_bins,

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,13 +19,12 @@ install_requires =
     emcee
     tqdm
     xarray
-    tarp @ git+https://github.com/maho3/tarp.git
+    tarp @ git+https://github.com/maho3/tarp.git#egg=tarp
 
     # pytorch backend
     torch;python_version>='3.7'
     sbi;python_version>='3.7'
     lampe;python_version>='3.7'
-    deprecation==2.1.0;python_version>='3.7'
     dask-ml;python_version>='3.7'
 
     # tensorflow backend

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     emcee
     tqdm
     xarray
-    tarp @ git+https://github.com/maho3/tarp.git@main
+    tarp @ git+https://github.com/maho3/tarp.git
 
     # pytorch backend
     torch;python_version>='3.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     emcee
     tqdm
     xarray
-    tarp @ git+https://github.com/maho3/tarp.git#egg=tarp
+    tarp @ git+https://github.com/maho3/tarp.git
 
     # pytorch backend
     torch;python_version>='3.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,12 +19,12 @@ install_requires =
     emcee
     tqdm
     xarray
+    tarp @ git+https://github.com/maho3/tarp.git@main
 
     # pytorch backend
     torch;python_version>='3.7'
     sbi;python_version>='3.7'
     lampe;python_version>='3.7'
-    tarp>=0.1.1;python_version>='3.7'
     deprecation==2.1.0;python_version>='3.7'
     dask-ml;python_version>='3.7'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     # tensorflow backend
     tensorflow==1.15;python_version<'3.7'
     dask-ml<2.0;python_version<'3.7'
-    pydelfi @ git+https://github.com/justinalsing/pydelfi.git ;python_version<'3.7'
+    pydelfi @ git+https://github.com/maho3/pydelfi.git ;python_version<'3.7'
 
 [options.extras_require]
 dev = 

--- a/tests/test_pydelfi.py
+++ b/tests/test_pydelfi.py
@@ -113,21 +113,6 @@ def test_toy():
     )
     assert samples.shape[1] == len(theta0)
 
-    # TARP not yet available with pydelfi
-    metric = PosteriorCoverage(
-        out_dir=Path('./toy_pydelfi'), num_samples=2,
-        sample_method='emcee', labels=[f'$\\theta_{i}$' for i in range(3)],
-        plot_list=["tarp"],
-        sample_params={'num_chains': 6},
-    )
-    unittest.TestCase().assertRaises(
-        NotImplementedError,
-        metric,
-        posterior=posterior,
-        x=x0,
-        theta=theta0
-    )
-
     #  Cannot sample directly with pydelfi
     metric = PosteriorCoverage(
         out_dir=Path('./toy_pydelfi'), num_samples=2,

--- a/tests/test_pydelfi.py
+++ b/tests/test_pydelfi.py
@@ -113,6 +113,15 @@ def test_toy():
     )
     assert samples.shape[1] == len(theta0)
 
+    # Check PosteriorCoverage metrics
+    metric = PosteriorCoverage(
+        out_dir=Path('./toy_pydelfi'), num_samples=10,
+        sample_method='emcee', labels=[f'$\\theta_{i}$' for i in range(3)],
+        plot_list=["coverage", "histogram", "predictions", "logprob", "tarp"],
+        sample_params={'num_chains': 8, 'burn_in': 1, 'thin': 1}
+    )
+    metric(posterior=posterior, x=x[:5], theta=theta[:5], num_alpha_bins=2)
+
     #  Cannot sample directly with pydelfi
     metric = PosteriorCoverage(
         out_dir=Path('./toy_pydelfi'), num_samples=2,


### PR DESCRIPTION
Two small changes to make pydelfi more compatible:
- We now install TARP from my github fork at https://github.com/maho3/tarp . This has allowed me to bypass the versioning restrictions for scipy and numpy which are present in the public (and deprecated) PyPI version. Seeing as Pablo may not be maintaining TARP, it is prudent to have our own version
- We also install pydelfi from my own fork at https://github.com/maho3/pydelfi . This version of pydelfi is nearly the same, except I've added a threading restriction to the Tensorflow.Session() object. The reason for this is, previously, Tensorflow was allowed to make unlimited threads which, on a restricted compute node, often caused a `std::system_error` and aborted the run. Now, we can throttle the threading, with the default set at 2 threads. My tests indicate that this throttling does not significantly impact runtime, as TF didn't need all those threads.

Solves #48 