### PR TITLE
hotfix to degrade sbi version to 0.22.0

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install coverage pytest
-          coverage combine .coverage_sbi .coverage_pydelfi .coverage_lampe
+          coverage combine coverage_sbi/.coverage_sbi coverage_pydelfi/.coverage_pydelfi coverage_lampe/.coverage_lampe
           coverage xml -o coverage.xml
           coverage report -m
         shell: bash

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install coverage pytest
-          coverage combine coverage_sbi/.coverage_sbi coverage_pydelfi/.coverage_pydelfi coverage_lampe/.coverage_lampe
+          coverage combine .coverage_sbi .coverage_pydelfi .coverage_lampe
           coverage xml -o coverage.xml
           coverage report -m
         shell: bash

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
 
     # pytorch backend
     torch;python_version>='3.7'
-    sbi;python_version>='3.7'
+    sbi<=0.22.0;python_version>='3.7'
     lampe;python_version>='3.7'
     dask-ml;python_version>='3.7'
 


### PR DESCRIPTION
`sbi` changed their object names as of `sbi==0.23.0`. A broad fix of this in ltu-ili will take a while, so this is a hotfix to enforce an earlier version in the `setup.cfg`