### PR TITLE
167 unit tests fail due to files not found

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,10 +30,10 @@ jobs:
       - name: Test with pytest
         run: |
           echo "Running sbi tests"
-	  COVERAGE_FILE=.coverage_sbi
-    	  echo "COVERAGE_FILE is set to: $COVERAGE_FILE"
-          python3 -m coverage run --source=ili -m pytest tests/test_sbi.py
+          COVERAGE_FILE=.coverage_sbi python3 -m coverage run --source=ili -m pytest tests/test_sbi.py
         shell: bash
+      - name: ls files
+        run: ls -aR
       - name: Archive sbi code coverage results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,17 +30,16 @@ jobs:
       - name: Test with pytest
         run: |
           echo "Running sbi tests"
-          COVERAGE_FILE=.coverage_sbi python3 -m coverage run --source=ili -m pytest tests/test_sbi.py
+          COVERAGE_FILE=coverage_file_sbi python3 -m coverage run --source=ili -m pytest tests/test_sbi.py
         shell: bash
       - name: ls files
         run: |
           ls -aR
-          cat .coverage_sbi
       - name: Archive sbi code coverage results
         uses: actions/upload-artifact@v4
         with:
           name: coverage_sbi
-          path: .coverage_sbi
+          path: coverage_file_sbi
         
   pydelfi_build:
 
@@ -64,13 +63,13 @@ jobs:
       - name: Test with pytest
         run: |
           echo "Running pydelfi tests"
-          COVERAGE_FILE=.coverage_pydelfi python3 -m coverage run --source=ili -m pytest tests/test_pydelfi.py
+          COVERAGE_FILE=coverage_file_pydelfi python3 -m coverage run --source=ili -m pytest tests/test_pydelfi.py
         shell: bash
       - name: Archive pydelfi code coverage results
         uses: actions/upload-artifact@v4
         with:
           name: coverage_pydelfi
-          path: .coverage_pydelfi
+          path: coverage_file_pydelfi
 
   lampe_build:
 
@@ -91,13 +90,13 @@ jobs:
       - name: Test with pytest
         run: |
           echo "Running lampe tests"
-          COVERAGE_FILE=.coverage_lampe python3 -m coverage run --source=ili -m pytest tests/test_lampe.py
+          COVERAGE_FILE=coverage_file_lampe python3 -m coverage run --source=ili -m pytest tests/test_lampe.py
         shell: bash
       - name: Archive lampe code coverage results
         uses: actions/upload-artifact@v4
         with:
           name: coverage_lampe
-          path: .coverage_lampe
+          path: coverage_file_lampe
 
   combine_tests:
     needs: [sbi_build, pydelfi_build, lampe_build]
@@ -117,7 +116,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install coverage pytest
-          coverage combine coverage_sbi/.coverage_sbi coverage_pydelfi/.coverage_pydelfi coverage_lampe/.coverage_lampe
+          coverage combine coverage_sbi/coverage_file_sbi coverage_pydelfi/coverage_file_pydelfi coverage_lampe/coverage_file_lampe
           coverage xml -o coverage.xml
           coverage report -m
         shell: bash

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,7 @@ name: unit-tests
 
 on:
   push:
-    branches: [ "main",  "167-unit-tests-fail-due-to-files-not-found"]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -32,9 +32,6 @@ jobs:
           echo "Running sbi tests"
           COVERAGE_FILE=coverage_file_sbi python3 -m coverage run --source=ili -m pytest tests/test_sbi.py
         shell: bash
-      - name: ls files
-        run: |
-          ls -aR
       - name: Archive sbi code coverage results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,7 +33,9 @@ jobs:
           COVERAGE_FILE=.coverage_sbi python3 -m coverage run --source=ili -m pytest tests/test_sbi.py
         shell: bash
       - name: ls files
-        run: ls -aR
+        run: |
+          ls -aR
+          cat .coverage_sbi
       - name: Archive sbi code coverage results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: ls files
         run: ls -aR
       - name: Archive sbi code coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage_sbi
           path: .coverage_sbi
@@ -65,7 +65,7 @@ jobs:
           COVERAGE_FILE=.coverage_pydelfi python3 -m coverage run --source=ili -m pytest tests/test_pydelfi.py
         shell: bash
       - name: Archive pydelfi code coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage_pydelfi
           path: .coverage_pydelfi
@@ -92,7 +92,7 @@ jobs:
           COVERAGE_FILE=.coverage_lampe python3 -m coverage run --source=ili -m pytest tests/test_lampe.py
         shell: bash
       - name: Archive lampe code coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage_lampe
           path: .coverage_lampe
@@ -108,7 +108,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Display structure of downloaded files
         run: ls -aR
       - name: Combine results of unit tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,10 +30,10 @@ jobs:
       - name: Test with pytest
         run: |
           echo "Running sbi tests"
-          COVERAGE_FILE=.coverage_sbi python3 -m coverage run --source=ili -m pytest tests/test_sbi.py
+	  COVERAGE_FILE=.coverage_sbi
+    	  echo "COVERAGE_FILE is set to: $COVERAGE_FILE"
+          python3 -m coverage run --source=ili -m pytest tests/test_sbi.py
         shell: bash
-      - name: Touch coverage file
-        run: touch .coverage_sbi
       - name: Archive sbi code coverage results
         uses: actions/upload-artifact@v3
         with:
@@ -64,8 +64,6 @@ jobs:
           echo "Running pydelfi tests"
           COVERAGE_FILE=.coverage_pydelfi python3 -m coverage run --source=ili -m pytest tests/test_pydelfi.py
         shell: bash
-      - name: Touch coverage file
-        run: touch .coverage_pydelfi
       - name: Archive pydelfi code coverage results
         uses: actions/upload-artifact@v3
         with:
@@ -93,8 +91,6 @@ jobs:
           echo "Running lampe tests"
           COVERAGE_FILE=.coverage_lampe python3 -m coverage run --source=ili -m pytest tests/test_lampe.py
         shell: bash
-      - name: Touch coverage file
-        run: touch .coverage_lampe
       - name: Archive lampe code coverage results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,7 @@ name: unit-tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main",  "167-unit-tests-fail-due-to-files-not-found"]
   pull_request:
     branches: [ "main" ]
 
@@ -32,6 +32,8 @@ jobs:
           echo "Running sbi tests"
           COVERAGE_FILE=.coverage_sbi python3 -m coverage run --source=ili -m pytest tests/test_sbi.py
         shell: bash
+      - name: Touch coverage file
+        run: touch .coverage_sbi
       - name: Archive sbi code coverage results
         uses: actions/upload-artifact@v3
         with:
@@ -62,6 +64,8 @@ jobs:
           echo "Running pydelfi tests"
           COVERAGE_FILE=.coverage_pydelfi python3 -m coverage run --source=ili -m pytest tests/test_pydelfi.py
         shell: bash
+      - name: Touch coverage file
+        run: touch .coverage_pydelfi
       - name: Archive pydelfi code coverage results
         uses: actions/upload-artifact@v3
         with:
@@ -89,6 +93,8 @@ jobs:
           echo "Running lampe tests"
           COVERAGE_FILE=.coverage_lampe python3 -m coverage run --source=ili -m pytest tests/test_lampe.py
         shell: bash
+      - name: Touch coverage file
+        run: touch .coverage_lampe
       - name: Archive lampe code coverage results
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
I have upgraded the upload/download from v3 to v4. It appears, though, that changing the file names for the coverage to not start with a "." is what was required to make this work.