### PR TITLE
Removes the requirement to specify `embedding_net` in `SBIRunner` initialization

### DIFF
--- a/ili/embedding/fcn.py
+++ b/ili/embedding/fcn.py
@@ -50,11 +50,9 @@ class FCN(nn.Module):
         Returns:
             torch.Tensor: data
         """
+        if len(x.shape) > 2:
+            x = x.view(x.shape[0], -1)
         if not hasattr(self, "mlp"):
-            if len(x.shape) == 1:
-                x = x.view(-1, 1)
-            elif len(x.shape) > 2:
-                x = x.view(x.shape[0], -1)
             self.initalize_model(x.shape[-1])
 
         return self.mlp(x)

--- a/ili/embedding/fcn.py
+++ b/ili/embedding/fcn.py
@@ -50,4 +50,11 @@ class FCN(nn.Module):
         Returns:
             torch.Tensor: data
         """
+        if not hasattr(self, "mlp"):
+            if len(x.shape) == 1:
+                x = x.view(-1, 1)
+            elif len(x.shape) > 2:
+                x = x.view(x.shape[0], -1)
+            self.initalize_model(x.shape[-1])
+
         return self.mlp(x)

--- a/ili/utils/ndes_pt.py
+++ b/ili/utils/ndes_pt.py
@@ -387,12 +387,10 @@ class _Lampe_Net_Constructor():
         )
 
     def __call__(self, x_batch, theta_batch, prior):
-        if hasattr(self.embedding_net, 'initalize_model'):
-            self.embedding_net.initalize_model(x_batch.shape[-1])
-        self.embedding_net = self.embedding_net.to(self.device)
 
         # pass data through embedding network
-        z_batch = self.embedding_net(x_batch)
+        z_batch = self.embedding_net(x_batch.cpu())
+        self.embedding_net = self.embedding_net.to(self.device)
         z_shape = z_batch.shape[1:]
         theta_shape = theta_batch.shape[1:]
 

--- a/notebooks/sbi.ipynb
+++ b/notebooks/sbi.ipynb
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-11-03T19:05:20.222429Z",
@@ -165,7 +165,6 @@
     "    prior=prior,\n",
     "    nets=nets,\n",
     "    device=device,\n",
-    "    embedding_net=None,\n",
     "    train_args=train_args,\n",
     "    proposal=None,\n",
     "    out_dir=None\n",
@@ -846,7 +845,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-11-03T18:58:07.435823Z",
@@ -878,7 +877,6 @@
     "    prior=prior,\n",
     "    nets=nets,\n",
     "    device=device,\n",
-    "    embedding_net=None,\n",
     "    train_args=train_args,\n",
     "    proposal=None,\n",
     "    out_dir=None\n",
@@ -1318,7 +1316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-11-03T19:09:22.946536Z",
@@ -1355,7 +1353,6 @@
     "    prior=prior,\n",
     "    nets=nets,\n",
     "    device=device,\n",
-    "    embedding_net=embedding_net,\n",
     "    train_args=train_args,\n",
     "    proposal=None,\n",
     "    out_dir=None\n",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ltu-ili
-version = 0.1.3
+version = 0.1.4
 description = implicit likelihood inference in astrophysics and cosmology
 
 [options]

--- a/tests/test_sbi.py
+++ b/tests/test_sbi.py
@@ -513,7 +513,6 @@ def test_multiround():
             engine=engine,
             nets=nets,
             device=device,
-            embedding_net=embedding_net,
             train_args=train_args,
             out_dir='./toy',
         )


### PR DESCRIPTION
Addresses #159 . `embedding_net` specification in `SBIRunner` was superfluous, for reasons given in the issue.

This was done by allowing FCN to initialize itself with a batch of data if it is called before initialization.