### PR TITLE
conforms Lampe/Pydelfi model initialization to sbi convention, to make it easier to switch between the various backends

### DIFF
--- a/ili/utils/ndes_pt.py
+++ b/ili/utils/ndes_pt.py
@@ -303,7 +303,6 @@ def load_nde_lampe(
             f'Engine {engine} not supported in lampe backend. '
             'You probably meant to specify engine="NPE" or to use the NLE or NRE'
             ' engines in the sbi or pydelfi backends.')
-
     model = model.lower()
 
     # check the model parameterizations

--- a/ili/utils/ndes_tf.py
+++ b/ili/utils/ndes_tf.py
@@ -13,6 +13,7 @@ All flow-based models (maf) have the configuration:
 
 import pydelfi
 import tensorflow as tf
+import logging
 
 
 def load_nde_pydelfi(
@@ -20,6 +21,7 @@ def load_nde_pydelfi(
     n_data: int,
     model: str,
     index: int = 0,
+    engine: str = 'NLE',
     **model_args
 ):
     """ Load an nde from pydelfi.
@@ -30,8 +32,14 @@ def load_nde_pydelfi(
         model (str): model to use. 
             One of: mdn, maf.
         index (int, optional): index of the nde in the ensemble. Defaults to 0.
+        engine (str, optional): dummy argument to match sbi interface.
+            Must be set to 'NLE' or will be overwritten.
         **model_args: additional arguments to pass to the model.
     """
+    if 'NLE' not in engine:
+        logging.warning(f'Engine {engine} not supported in pydelfi backend. '
+                        'Continuing as if to engine=NLE.')
+
     if model == 'mdn':
         if not (set(model_args.keys()) <= {'hidden_features', 'num_components'}):
             raise ValueError(f"Model {model} arguments mispecified.")

--- a/ili/utils/ndes_tf.py
+++ b/ili/utils/ndes_tf.py
@@ -37,36 +37,45 @@ def load_nde_pydelfi(
         **model_args: additional arguments to pass to the model.
     """
     if 'NLE' not in engine:
-        logging.warning(f'Engine {engine} not supported in pydelfi backend. '
-                        'Continuing as if to engine=NLE.')
+        raise ValueError(
+            f'Engine {engine} not supported in pydelfi backend. '
+            'You probably meant to specify engine="NLE" or to use the NPE or NRE'
+            ' engines in the sbi or lampe backends.')
+    model = model.lower()
 
+    # check the model parameterizations
     if model == 'mdn':
-        if not (set(model_args.keys()) <= {'hidden_features', 'num_components'}):
-            raise ValueError(f"Model {model} arguments mispecified.")
-        cfg = {'hidden_features': 50, 'num_components': 1}
-        cfg.update(model_args)
-        n_hidden = [cfg['hidden_features']] * 3
+        model_defaults = dict(hidden_features=16, num_components=3)
+    else:
+        model_defaults = dict(hidden_features=16, num_transforms=2)
+    if not (set(model_args.keys()) <= set(model_defaults.keys())):
+        raise ValueError(
+            f"Model {model} arguments mispecified. Extra arguments found: "
+            f"{set(model_args.keys()) - set(model_defaults.keys())}.")
+
+    # set defaults
+    model_args = {**model_defaults, **model_args}
+
+    # setup models
+    if model == 'mdn':
+        n_hidden = [model_args['hidden_features']] * 3
         activations = [tf.tanh] * 3
         return pydelfi.ndes.MixtureDensityNetwork(
             n_parameters=n_params,
             n_data=n_data,
-            n_components=cfg['num_components'],
+            n_components=model_args['num_components'],
             n_hidden=n_hidden,
             activations=activations,
             index=index,
         )
     elif model == 'maf':
-        if not (set(model_args.keys()) <= {'hidden_features', 'num_transforms'}):
-            raise ValueError(f"Model {model} arguments mispecified.")
-        cfg = {'hidden_features': 50, 'num_transforms': 4}
-        cfg.update(model_args)
-        n_hidden = [cfg['hidden_features']] * \
-            cfg['num_transforms']
+        n_hidden = [model_args['hidden_features']] * \
+            model_args['num_transforms']
         return pydelfi.ndes.ConditionalMaskedAutoregressiveFlow(
             n_parameters=n_params,
             n_data=n_data,
             n_hiddens=n_hidden,
-            n_mades=cfg['num_transforms'],
+            n_mades=model_args['num_transforms'],
             act_fun=tf.tanh,
             index=index,
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ltu-ili
-version = 0.1.4
+version = 0.1.5
 description = implicit likelihood inference in astrophysics and cosmology
 
 [options]

--- a/tests/test_lampe.py
+++ b/tests/test_lampe.py
@@ -81,6 +81,14 @@ def test_npe(monkeypatch):
         for name in ['maf', 'nsf', 'ncsf', 'nice', 'gf', 'sospf', 'naf', 'unaf', 'cnf']
     ]
 
+    # check that we throw an error for misspecified arguments
+    unittest.TestCase().assertRaises(
+        ValueError, ili.utils.load_nde_lampe, model='mdn', engine='NLE')
+    unittest.TestCase().assertRaises(
+        ValueError, ili.utils.load_nde_lampe, model='mdn', num_transforms=2)
+    unittest.TestCase().assertRaises(
+        ValueError, ili.utils.load_nde_lampe, model='maf', num_components=2)
+
     # initialize the trainer
     runner = LampeRunner(
         prior=prior,
@@ -115,6 +123,8 @@ def test_npe(monkeypatch):
 
     # generate samples from the posterior using accept/reject sampling
     samples = posterior.sample((nsamples,), torch.Tensor(x[ind]).to(device))
+    _ = posterior.sample(nsamples, x[ind])  # test input casting
+    _ = posterior.posteriors[0].sample(0, x[ind])  # test input casting
 
     # calculate the log_prob for each sample
     log_prob = posterior.log_prob(samples, torch.Tensor(x[ind]).to(device))

--- a/tests/test_pydelfi.py
+++ b/tests/test_pydelfi.py
@@ -474,7 +474,7 @@ def test_universal():
         NotImplementedError,
         load_nde_pydelfi,
         n_params=theta.shape[1], n_data=x.shape[1],
-        model='nsf', hidden_features=50, num_components=2
+        model='nsf', hidden_features=50, num_transforms=5
     )
 
     # test that it works if you underspecify

--- a/tests/test_pydelfi.py
+++ b/tests/test_pydelfi.py
@@ -460,6 +460,13 @@ def test_universal():
     unittest.TestCase().assertRaises(
         ValueError,
         load_nde_pydelfi,
+        engine='NPE',
+        n_params=theta.shape[1], n_data=x.shape[1],
+        model='mdn', hidden_features=50, num_transforms=5
+    )
+    unittest.TestCase().assertRaises(
+        ValueError,
+        load_nde_pydelfi,
         n_params=theta.shape[1], n_data=x.shape[1],
         model='mdn', hidden_features=50, num_transforms=5
     )


### PR DESCRIPTION
Implements tasks in #153 