### PR TITLE
Enable pydelfi tests for Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-pydelfi.yml
+++ b/.github/workflows/build-pydelfi.yml
@@ -25,16 +25,20 @@ jobs:
           sudo apt-get install -y make build-essential libssl-dev zlib1g-dev \
                                   libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
                                   libncurses5-dev libncursesw5-dev xz-utils tk-dev
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
           curl https://pyenv.run | bash
-          echo 'export PYENV_ROOT="$HOME/.pyenv"' >> $GITHUB_ENV
-          echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> $GITHUB_ENV
-          echo 'eval "$(pyenv init --path)"' >> $GITHUB_ENV
-          echo 'eval "$(pyenv init -)"' >> $GITHUB_ENV
-          source $HOME/.pyenv/bin/pyenv
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init -)"
+          eval "$(pyenv virtualenv-init -)"
           pyenv install 3.6
           pyenv global 3.6
       - name: Check Python version
-        run: python --version
+        run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
+          eval "$(pyenv init -)"
+          python --version
         
       - name: Setup MPI
         uses: mpi4py/setup-mpi@v1
@@ -42,6 +46,9 @@ jobs:
           mpi: 'openmpi'
       - name: Install dependencies
         run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
+          eval "$(pyenv init -)"
           python -m pip install --upgrade pip
           pip install -e .[dev]
       - name: Lint with Ruff

--- a/.github/workflows/build-pydelfi.yml
+++ b/.github/workflows/build-pydelfi.yml
@@ -46,13 +46,10 @@ jobs:
           mpi: 'openmpi'
       - name: Install dependencies
         run: |
-          export PYENV_ROOT="$HOME/.pyenv"
-          export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
-          eval "$(pyenv init -)"
           python -m pip install --upgrade pip
           pip install -e .[dev]
       - name: Lint with Ruff
         run: |
           pip install ruff
-          ruff --format=github --target-version=py37 .
+          ruff check .
         continue-on-error: true

--- a/.github/workflows/build-pydelfi.yml
+++ b/.github/workflows/build-pydelfi.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-pydelfi.yml
+++ b/.github/workflows/build-pydelfi.yml
@@ -19,10 +19,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.6"
+      - name: Install pyenv and Python 3.6
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make build-essential libssl-dev zlib1g-dev \
+                                  libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+                                  libncurses5-dev libncursesw5-dev xz-utils tk-dev
+          curl https://pyenv.run | bash
+          echo 'export PYENV_ROOT="$HOME/.pyenv"' >> $GITHUB_ENV
+          echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> $GITHUB_ENV
+          echo 'eval "$(pyenv init --path)"' >> $GITHUB_ENV
+          echo 'eval "$(pyenv init -)"' >> $GITHUB_ENV
+          source $HOME/.pyenv/bin/pyenv
+          pyenv install 3.6
+          pyenv global 3.6
+      - name: Check Python version
+        run: python --version
       - name: Setup MPI
         uses: mpi4py/setup-mpi@v1
         with:

--- a/.github/workflows/build-pydelfi.yml
+++ b/.github/workflows/build-pydelfi.yml
@@ -35,6 +35,7 @@ jobs:
           pyenv global 3.6
       - name: Check Python version
         run: python --version
+        
       - name: Setup MPI
         uses: mpi4py/setup-mpi@v1
         with:

--- a/.github/workflows/build-sbi.yml
+++ b/.github/workflows/build-sbi.yml
@@ -5,7 +5,7 @@ name: build-sbi
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/build-sbi.yml
+++ b/.github/workflows/build-sbi.yml
@@ -5,7 +5,7 @@ name: build-sbi
 
 on:
   push:
-    branches: [ ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,7 @@ name: unit-tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -70,6 +70,9 @@ jobs:
           mpi: 'openmpi'
       - name: Install dependencies
         run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
+          eval "$(pyenv init -)"
           python --version
           python3 --version
           python -m pip install --upgrade pip

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,7 @@ name: unit-tests
 
 on:
   push:
-    branches: [ ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -40,14 +40,30 @@ jobs:
         
   pydelfi_build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.6"
+      - name: Install pyenv and Python 3.6
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make build-essential libssl-dev zlib1g-dev \
+                                  libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+                                  libncurses5-dev libncursesw5-dev xz-utils tk-dev
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          curl https://pyenv.run | bash
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init -)"
+          eval "$(pyenv virtualenv-init -)"
+          pyenv install 3.6
+          pyenv global 3.6
+      - name: Check Python version
+        run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
+          eval "$(pyenv init -)"
+          python --version
       - name: Setup MPI
         uses: mpi4py/setup-mpi@v1
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -81,6 +81,10 @@ jobs:
       - name: Test with pytest
         run: |
           echo "Running pydelfi tests"
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
+          eval "$(pyenv init -)"
+          python3 --version
           COVERAGE_FILE=coverage_file_pydelfi python3 -m coverage run --source=ili -m pytest tests/test_pydelfi.py
         shell: bash
       - name: Archive pydelfi code coverage results

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -74,7 +74,6 @@ jobs:
           export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
           eval "$(pyenv init -)"
           python --version
-          python3 --version
           python -m pip install --upgrade pip
           python -m pip install flake8 pytest
           python -m pip install -e .[dev]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -70,9 +70,11 @@ jobs:
           mpi: 'openmpi'
       - name: Install dependencies
         run: |
+          python --version
+          python3 --version
           python -m pip install --upgrade pip
-          pip install flake8 pytest
-          pip install -e .[dev]
+          python -m pip install flake8 pytest
+          python -m pip install -e .[dev]
       - name: Test with pytest
         run: |
           echo "Running pydelfi tests"


### PR DESCRIPTION
As described in #185 , Github actions no longer supports Ubuntu==20.04 and therefore python3.6 is not available by default. This causes the pydelfi unit tests and build tests to fail, since pydelfi requires tensorflow1, which is not supported by later python versions. Instead of simply removing pydelfi or its unit tests (suggested in #185), in this PR I instead install python3.6 during the workflows for pydelfi and therefore enable the tests to run as before.