### PR TITLE
bugfixes to adapt to the new sbi v0.23

### DIFF
--- a/ili/inference/runner_sbi.py
+++ b/ili/inference/runner_sbi.py
@@ -240,7 +240,7 @@ class SBIRunner(_BaseRunner):
             if model._neural_net is None:
                 model.train(learning_rate=self.train_args['learning_rate'],
                             resume_training=False,
-                            max_num_epochs=-1)
+                            max_num_epochs=2**31-1)
                 model._epochs_since_last_improvement = 0
                 first_round = True
 

--- a/ili/utils/distributions_pt.py
+++ b/ili/utils/distributions_pt.py
@@ -41,6 +41,14 @@ class CustomIndependent(Independent):
         self.dist = self.Distribution(*args, **kwargs)
         return super().__init__(self.dist, 1)
 
+    def to(self, device):
+        self.device = device
+        for param_name in self.dist.arg_constraints.keys():
+            param = getattr(self.dist, param_name, None)
+            if isinstance(param, torch.Tensor):
+                setattr(self.dist, param_name, param.to(device))
+        return self
+
 
 # Load and wrap distributions
 dist_dict = {}


### PR DESCRIPTION
Solves #205 

Implements:
* A high `max_num_epochs`, because `max_num_epochs=-1` is no longer allowed
* Adding a `.to` function to `CustomIndependent`, as sbi's PosteriorEnsmebles now require it.