### PR TITLE
Expose kwargs of underlying models when sampling

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -141,6 +141,7 @@ jobs:
           coverage report -m
         shell: bash
       - name: Upload coverage report to Codecov
+        if: github.event.pull_request.head.repo.fork == false
         uses: codecov/codecov-action@v3
         with:
           files: ${{ github.workspace }}/coverage.xml

--- a/ili/utils/samplers.py
+++ b/ili/utils/samplers.py
@@ -330,4 +330,4 @@ class VISampler(ABC):
             quality_control=False,
             **self.train_kwargs
         )
-        return self.posterior.sample((nsteps,)).detach().cpu().numpy()
+        return self.posterior.sample((nsteps,), **kwargs).detach().cpu().numpy()

--- a/ili/utils/samplers.py
+++ b/ili/utils/samplers.py
@@ -70,7 +70,7 @@ class EmceeSampler(_MCMCSampler):
 
     def sample(self, nsteps: int, x: np.ndarray,
                progress: bool = False,
-               skip_initial_state_check: bool = False) -> np.ndarray:
+               skip_initial_state_check: bool = False, **kwargs) -> np.ndarray:
         """
         Sample nsteps samples from the posterior, evaluated at data x.
 
@@ -82,6 +82,8 @@ class EmceeSampler(_MCMCSampler):
             skip_initial_state_check (bool, optional): If True, a check that 
                 the initial_state can fully explore the space will be skipped. 
                 Defaults to False.
+            **kwargs: additional keyword arguments to pass to the
+            posterior's sample method (if applicable, not used for emcee sampling)
         """
         # calculate number of samples per chain
         per_chain = ceil(nsteps / self.num_chains)
@@ -185,7 +187,7 @@ class PyroSampler(_MCMCSampler):
         )
 
     def sample(self, nsteps: int, x: np.ndarray,
-               progress: bool = False) -> np.ndarray:
+               progress: bool = False, **kwargs) -> np.ndarray:
         """
         Sample nsteps samples from the posterior, evaluated at data x.
 
@@ -194,6 +196,8 @@ class PyroSampler(_MCMCSampler):
             x (np.ndarray): data to evaluate the posterior at
             progress (bool, optional): whether to show progress bar.
                 Defaults to False.
+            **kwargs: additional keyword arguments to pass to the
+            posterior's sample method.
         """
         return self.posterior.sample(
             (nsteps,),
@@ -202,7 +206,8 @@ class PyroSampler(_MCMCSampler):
             num_chains=self.num_chains,
             thin=self.thin,
             warmup_steps=self.burn_in,
-            show_progress_bars=progress
+            show_progress_bars=progress,
+            **kwargs
         ).detach().cpu().numpy()
 
 
@@ -218,7 +223,7 @@ class DirectSampler(ABC):
     def __init__(self, posterior: ModelClass) -> None:
         self.posterior = posterior
 
-    def sample(self, nsteps: int, x: Any, progress: bool = False) -> np.ndarray:
+    def sample(self, nsteps: int, x: Any, progress: bool = False, **kwargs) -> np.ndarray:
         """
         Sample nsteps samples from the posterior, evaluated at data x.
 
@@ -227,6 +232,8 @@ class DirectSampler(ABC):
             x (np.ndarray): data to evaluate the posterior at
             progress (bool, optional): whether to show progress bar.
                 Defaults to False.
+            **kwargs: additional keyword arguments to pass to the 
+            posterior's sample method
         """
         try:
             x = torch.as_tensor(x)
@@ -236,7 +243,8 @@ class DirectSampler(ABC):
             pass
         return self.posterior.sample(
             (nsteps,), x=x,
-            show_progress_bars=progress
+            show_progress_bars=progress,
+            **kwargs
         ).detach().cpu().numpy()
 
 
@@ -294,7 +302,7 @@ class VISampler(ABC):
         )
 
     def sample(self, nsteps: int, x: np.ndarray,
-               progress: bool = False) -> np.ndarray:
+               progress: bool = False, **kwargs) -> np.ndarray:
         """
         Sample nsteps samples from the posterior, evaluated at data x.
 
@@ -303,6 +311,8 @@ class VISampler(ABC):
             x (np.ndarray): data to evaluate the posterior at
             progress (bool, optional): whether to show progress bar.
                 Defaults to False.
+            **kwargs: additional keyword arguments to pass to the
+            posterior's sample method.
         """
         x = torch.Tensor(x).to(self.posterior._device)
         self.posterior.set_default_x(x)

--- a/ili/utils/samplers.py
+++ b/ili/utils/samplers.py
@@ -79,12 +79,20 @@ class EmceeSampler(_MCMCSampler):
             x (np.ndarray): data to evaluate the posterior at
             progress (bool, optional): whether to show progress bar.
                 Defaults to False.
-            skip_initial_state_check (bool, optional): If True, a check that 
-                the initial_state can fully explore the space will be skipped. 
+            skip_initial_state_check (bool, optional): If True, a check that
+                the initial_state can fully explore the space will be skipped.
                 Defaults to False.
-            **kwargs: additional keyword arguments to pass to the
-            posterior's sample method (if applicable, not used for emcee sampling)
+            **kwargs: unexpected keyword arguments. Emcee sampling does not
+                support additional keyword arguments and will raise an error
+                if any are provided.
         """
+        if kwargs:
+            unexpected = ", ".join(sorted(kwargs))
+            raise TypeError(
+                f"EmceeSampler.sample() got unexpected keyword argument(s): "
+                f"{unexpected}"
+            )
+
         # calculate number of samples per chain
         per_chain = ceil(nsteps / self.num_chains)
 

--- a/tests/test_sbi.py
+++ b/tests/test_sbi.py
@@ -12,6 +12,7 @@ import xarray as xr
 import csv
 import json
 import unittest
+from unittest.mock import MagicMock, patch
 
 import ili
 from ili.dataloaders import (
@@ -1557,3 +1558,91 @@ def test_misc():
         runner,
         loader=loader
     )
+
+
+def test_sampler_kwargs():
+    """Test that **kwargs are forwarded (or rejected) correctly by each sampler.
+
+    Uses mocks so no full model training is required.
+    """
+    from ili.utils.samplers import EmceeSampler, DirectSampler, PyroSampler, VISampler
+
+    # ------------------------------------------------------------------
+    # EmceeSampler: unknown kwargs must raise TypeError immediately,
+    # before any sampling work is done.
+    # ------------------------------------------------------------------
+    mock_posterior = MagicMock()
+    emcee_sampler = EmceeSampler.__new__(EmceeSampler)
+    emcee_sampler.posterior = mock_posterior
+    emcee_sampler.num_chains = 2
+    emcee_sampler.thin = 1
+    emcee_sampler.burn_in = 0
+
+    unittest.TestCase().assertRaises(
+        TypeError,
+        emcee_sampler.sample,
+        2,
+        np.zeros(4),
+        unknown_kwarg=True,
+    )
+
+    # ------------------------------------------------------------------
+    # DirectSampler: extra kwargs must be forwarded to posterior.sample().
+    # ------------------------------------------------------------------
+    mock_posterior = MagicMock()
+    mock_posterior._device = 'cpu'
+    mock_posterior.sample.return_value = torch.zeros(2, 3)
+
+    direct_sampler = DirectSampler(mock_posterior)
+    direct_sampler.sample(2, x=np.zeros(4), extra_kwarg='sentinel')
+
+    call_kwargs = mock_posterior.sample.call_args[1]
+    unittest.TestCase().assertIn(
+        'extra_kwarg', call_kwargs,
+        "DirectSampler.sample() must forward **kwargs to posterior.sample()"
+    )
+    unittest.TestCase().assertEqual(call_kwargs['extra_kwarg'], 'sentinel')
+
+    # ------------------------------------------------------------------
+    # PyroSampler: extra kwargs must be forwarded to posterior.sample().
+    # ------------------------------------------------------------------
+    mock_posterior = MagicMock()
+    mock_posterior._device = 'cpu'
+    mock_posterior.sample.return_value = torch.zeros(2, 3)
+
+    pyro_sampler = PyroSampler.__new__(PyroSampler)
+    pyro_sampler.posterior = mock_posterior
+    pyro_sampler.method = 'slice_np_vectorized'
+    pyro_sampler.num_chains = 1
+    pyro_sampler.thin = 1
+    pyro_sampler.burn_in = 0
+
+    pyro_sampler.sample(2, x=np.zeros(4), extra_kwarg='sentinel')
+
+    call_kwargs = mock_posterior.sample.call_args[1]
+    unittest.TestCase().assertIn(
+        'extra_kwarg', call_kwargs,
+        "PyroSampler.sample() must forward **kwargs to posterior.sample()"
+    )
+    unittest.TestCase().assertEqual(call_kwargs['extra_kwarg'], 'sentinel')
+
+    # ------------------------------------------------------------------
+    # VISampler: extra kwargs must be forwarded to posterior.sample().
+    # ------------------------------------------------------------------
+    mock_posterior = MagicMock()
+    mock_posterior._device = 'cpu'
+    mock_posterior.sample.return_value = torch.zeros(2, 3)
+
+    vi_sampler = VISampler.__new__(VISampler)
+    vi_sampler.posterior = mock_posterior
+    vi_sampler.dist = 'maf'
+    vi_sampler.train_kwargs = {}
+
+    vi_sampler.sample(2, x=np.zeros(4), extra_kwarg='sentinel')
+
+    call_kwargs = mock_posterior.sample.call_args[1]
+    unittest.TestCase().assertIn(
+        'extra_kwarg', call_kwargs,
+        "VISampler.sample() must forward **kwargs to posterior.sample()"
+    )
+    unittest.TestCase().assertEqual(call_kwargs['extra_kwarg'], 'sentinel')


### PR DESCRIPTION
Hi all,

I'd like to implement this relatively simple change to the samplers to allow for abitrary keyword argument passthrough to the underlying posterior objects. It would be useful to e.g. set  `max_sampling_batch_size`, `reject_outside_prior`, `max_sampling_time`, `return_partial_on_timeout` on the sample method of `DirectPosterior`, or similar arguments on the other sample methods. These changes shouldn't cause any issues, as nothing will happen if no additional arguments are passed. The alternative would be to manually pass through all the relevant arguments, but this would be significantly more fragile. 