### PR TITLE
Introduces moment networks and bugfixes

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -170,10 +170,11 @@ Only certain NDEs and training engines are compatible with either the sbi or pyd
 The `moment` model is a lampe-only `NPE` option. Unlike the flows, it does not
 learn a full joint density: it is a Moment Network ([Jeffrey & Wandelt 2020](https://arxiv.org/abs/2011.05991))
 that approximates the posterior as a single full-covariance Gaussian
-`N(mu(x), Sigma(x))`. It trains via an internal two-stage procedure (a mean
-network fit with MSE against `theta`, then a covariance network fit against the
-frozen residual products), rather than the standard joint NPE loss, but is used
-identically from the config/API — just set `model: 'moment'`. It accepts
+`N(mu(x), Sigma(x))`. Its mean and covariance networks are optimized jointly
+in a single pass (the covariance loss uses a stop-gradient copy of the mean,
+so it doesn't pull on the mean network), rather than the standard joint NPE
+loss, but is used identically from the config/API — just set `model:
+'moment'`. It accepts
 `hidden_features`, `hidden_depth`, `activation`, and `embedding_net`; flow-only
 args like `num_transforms` are ignored with a warning. Because a standalone
 `moment` posterior is unimodal/Gaussian (not a flexible density), it is best

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -163,9 +163,21 @@ Only certain NDEs and training engines are compatible with either the sbi or pyd
 
 | Training Engine | sbi | pydelfi | lampe |
 |----------|----------|----------|----------|
-|  `NPE`,`SNPE`   |   mdn, maf, nsf, made   |      | maf, nsf, cnf, nice, gf, sospf, naf, unaf |
+|  `NPE`,`SNPE`   |   mdn, maf, nsf, made   |      | maf, nsf, cnf, nice, gf, sospf, naf, unaf, moment |
 |  `NLE`, `SNLE`   |   mdn, maf, nsf, made   |   mdn, maf   | |
 |  `NRE`, `SNRE`   |   linear, mlp, resnet   |      | | |
+
+The `moment` model is a lampe-only `NPE` option. Unlike the flows, it does not
+learn a full joint density: it is a Moment Network ([Jeffrey & Wandelt 2020](https://arxiv.org/abs/2011.05991))
+that approximates the posterior as a single full-covariance Gaussian
+`N(mu(x), Sigma(x))`. It trains via an internal two-stage procedure (a mean
+network fit with MSE against `theta`, then a covariance network fit against the
+frozen residual products), rather than the standard joint NPE loss, but is used
+identically from the config/API — just set `model: 'moment'`. It accepts
+`hidden_features`, `hidden_depth`, `activation`, and `embedding_net`; flow-only
+args like `num_transforms` are ignored with a warning. Because a standalone
+`moment` posterior is unimodal/Gaussian (not a flexible density), it is best
+used as one member of an ensemble alongside real flows.
 
 Lastly, the **train_args** are used to configure the training optimizer, the early stopping criterion, and the number of rounds of inference (for Sequential models). All engines use the Adam optimizer. Lastly, **device** specifies whether to use Pytorch's `cpu` or `cuda` backend, and **out_dir** specifies where to save your models after they are done training.
 

--- a/ili/inference/lampe_moment.py
+++ b/ili/inference/lampe_moment.py
@@ -1,27 +1,31 @@
 """
-Standalone two-stage trainer and estimator for Moment Networks
+Standalone trainer and estimator for Moment Networks
 (Jeffrey & Wandelt 2020, arXiv:2011.05991) in the lampe backend.
 
 A Moment Network does not learn a full joint density like the zuko flows that
 the lampe backend usually wraps. Instead it directly regresses the posterior
-mean and covariance:
+mean and covariance, with the mean network (f_mu) and covariance network
+(f_cov) optimized jointly in a single pass:
 
-    Stage 1 (mean network):
-        f_mu(x) -> mu, trained with plain MSE against the true parameters theta.
+    f_mu(x)  -> mu
+    f_cov(x) -> raw Cholesky entries -> L -> Sigma = L L^T
 
-    Stage 2 (covariance network), trained *after* Stage 1 is frozen:
-        resid    = theta - f_mu(x)              # frozen, no gradient
-        target   = vech(resid resid^T)          # residual products, i<=j
-        f_cov(x) -> raw Cholesky entries -> L -> Sigma = L L^T
-        loss     = MSE(vech(Sigma), target)     # plain MSE
+    resid  = theta - mu.detach()        # stop-gradient: cov term doesn't
+                                         # backprop into f_mu
+    target = vech(resid resid^T)        # residual products, i<=j
+    loss   = logsum_sq(theta - mu) + logsum_sq(vech(Sigma) - target)
 
-    Because E[resid resid^T | x] = Sigma(x), minimizing the MSE between
-    vech(Sigma) and the residual-product targets drives L L^T towards the true
-    conditional covariance, while the Cholesky parameterization (lower
-    triangular, softplus on the diagonal) guarantees Sigma is positive-definite
-    by construction. This reconciles the reference implementation's
-    "regress toward residual products" targets with the requirement to output a
-    valid covariance.
+where ``logsum_sq(err) = sum_j log(sum_batch(err_j^2) + floor)``: a per-output
+loss that sums squared error over the batch *before* taking a log, rather than
+averaging error directly (plain MSE). This keeps gradients comparably scaled
+across output dimensions (mean components and covariance entries alike) even
+though their natural magnitudes differ substantially, which is what makes the
+joint fit converge reliably in practice.
+
+Because E[resid resid^T | x] = Sigma(x), driving vech(Sigma) toward the
+residual-product targets pushes L L^T towards the true conditional covariance,
+while the Cholesky parameterization (lower triangular, softplus on the
+diagonal) guarantees Sigma is positive-definite by construction.
 
 The resulting posterior is a single (full-covariance) Gaussian approximation.
 It is *not* a flexible density -- it is unimodal and Gaussian -- so on its own
@@ -29,7 +33,7 @@ it can only capture Gaussian posteriors. It is most useful as one member of an
 ensemble alongside real flows (maf/nsf/...), where it is sampled and log_prob'd
 identically via a torch MultivariateNormal.
 
-This module is self-contained: the two-stage training lives entirely inside
+This module is self-contained: the joint training lives entirely inside
 ``train_moment_network``, and the trained ``MomentNetworkEstimator`` is a
 drop-in ensemble member (it subclasses ``LampeNPE`` to reuse its accept-reject
 sampling and device handling).
@@ -60,7 +64,10 @@ _ACTIVATIONS = {
 
 
 def _make_mlp(in_dim, out_dim, hidden_features, hidden_depth, activation):
-    """Build a simple MLP trunk with ``hidden_depth`` hidden layers."""
+    """Build a simple constant-width MLP trunk with ``hidden_depth`` hidden
+    layers of width ``hidden_features`` (mirrors the mdn model's own
+    architecture args). Any funnel-shaped compression belongs upstream, in
+    the embedding_net (e.g. embedding_net='fun'), not in this trunk."""
     act = _ACTIVATIONS[activation]
     layers, d = [], in_dim
     for _ in range(hidden_depth):
@@ -140,14 +147,12 @@ class MomentNetworkEstimator(LampeNPE):
         return L
 
     def predict_moments(self, x):
-        """Return (mu, L) in normalized theta space for input data x.
-
-        mu has shape (B, n_params); L is a (B, n_params, n_params) lower-
-        triangular Cholesky factor with Sigma = L @ L.T.
-        """
+        """Return (mu, L) in normalized theta space for input data x."""
         if isinstance(x, (list, np.ndarray)):
             x = torch.Tensor(x)
         x = x.to(self._device)
+        if x.dim() == 1:
+            x = x.unsqueeze(0)
         xin = self.x_transform.inv(x).float()
         mu = self.mu_net(self.emb_mu(xin))
         L = self._build_L(self.cov_net(self.emb_cov(xin)))
@@ -190,7 +195,7 @@ class _Lampe_Moment_Constructor():
 
     Constructed by ``load_nde_lampe(model='moment', ...)`` and called later as
     ``constructor(train_loader, prior)`` to build an (untrained)
-    ``MomentNetworkEstimator``. The actual two-stage fit is performed
+    ``MomentNetworkEstimator``. The actual joint fit is performed
     separately by ``train_moment_network``; the runner detects this net via the
     ``is_moment`` marker and routes it there.
     """
@@ -228,7 +233,8 @@ class _Lampe_Moment_Constructor():
             scaler = StandardScaler()
             for _, theta_batch in train_loader:
                 scaler.partial_fit(theta_batch.cpu().numpy())
-            theta_mean = torch.tensor(scaler.mean_, dtype=dtype).to(self.device)
+            theta_mean = torch.tensor(
+                scaler.mean_, dtype=dtype).to(self.device)
             theta_std = torch.clamp(
                 torch.tensor(scaler.scale_, dtype=dtype).to(self.device),
                 min=1e-16)
@@ -269,7 +275,8 @@ class _Lampe_Moment_Constructor():
             z_dim, n_cov, hidden_features, hidden_depth, activation
         ).to(self.device)
 
-        x_transform, theta_transform = self._fit_transforms(train_loader, dtype)
+        x_transform, theta_transform = self._fit_transforms(
+            train_loader, dtype)
 
         estimator = MomentNetworkEstimator(
             emb_mu=emb_mu, mu_net=mu_net,
@@ -285,8 +292,9 @@ def _fit_stage(modules, loss_fn, train_loader, val_loader,
     """Train a set of modules to convergence via MSE with early stopping.
 
     Generic single-stage optimizer loop, following the same early-stopping /
-    patience / lr conventions as the shared lampe trainer. Returns
-    (train_trace, val_trace, best_val_loss) and restores the best weights.
+    patience / lr / scheduler conventions as the shared lampe trainer.
+    Returns (train_trace, val_trace, best_val_loss) and restores the best
+    weights.
     """
     from tqdm import tqdm
 
@@ -297,6 +305,21 @@ def _fit_stage(modules, loss_fn, train_loader, val_loader,
     clip = train_args["clip_max_norm"]
     early_stopping = train_args.get("early_stopping", True)
     max_epochs = int(train_args["max_epochs"])
+
+    scheduler_name = train_args.get('lr_scheduler', 'ReduceLROnPlateau')
+    if scheduler_name == 'ReduceLROnPlateau':
+        if train_args["lr_decay_factor"] < 1:
+            scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+                optimizer, factor=train_args["lr_decay_factor"],
+                patience=train_args["lr_patience"])
+        else:
+            scheduler = torch.optim.lr_scheduler.LambdaLR(
+                optimizer, lr_lambda=lambda epoch: 1.0)
+    elif scheduler_name == 'CosineAnnealingLR':
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optimizer, T_max=max_epochs, eta_min=0)
+    else:
+        raise ValueError(f"Unknown lr_scheduler: {scheduler_name}")
 
     best_val = float('inf')
     best_state = [deepcopy(m.state_dict()) for m in modules]
@@ -331,6 +354,11 @@ def _fit_stage(modules, loss_fn, train_loader, val_loader,
                     cnt += len(theta)
                 val_loss = tot / cnt
 
+            if scheduler_name == 'ReduceLROnPlateau':
+                scheduler.step(val_loss)
+            else:
+                scheduler.step()
+
             train_trace.append(train_loss)
             val_trace.append(val_loss)
             tq.set_postfix(mse=train_loss, mse_val=val_loss)
@@ -354,61 +382,57 @@ def _fit_stage(modules, loss_fn, train_loader, val_loader,
     return train_trace, val_trace, best_val
 
 
+_VAR_FLOOR = 1e-6  # matches the softplus floor used in MomentNetworkEstimator._build_L
+
+
+def _logsum_sq(err):
+    """sum_j log(sum_batch(err_j^2) + floor): keeps gradients comparably
+    scaled across output dimensions of differing natural magnitude, unlike
+    plain per-sample MSE."""
+    return torch.log((err ** 2).sum(0) + _VAR_FLOOR).sum()
+
+
 def train_moment_network(estimator: MomentNetworkEstimator,
                          train_loader, val_loader,
                          train_args, device, verbose=True):
-    """Run the two-stage Moment Network fit in place on ``estimator``.
+    """Jointly fit the mean and covariance networks of a Moment Network.
 
-    Stage 1 fits the mean network with MSE against theta. Stage 2 freezes it,
-    derives residual-product targets, and fits the covariance network so that
-    vech(L L^T) matches those targets. Returns a summary dict shaped like the
-    shared lampe trainer's summaries (so ensembling/plotting code is unchanged).
+    Both networks are optimized together in a single pass: the mean loss
+    backpropagates into ``emb_mu``/``mu_net``, while the covariance loss
+    backpropagates into ``emb_cov``/``cov_net`` only (the residuals it
+    targets use a stop-gradient copy of mu, so the mean net isn't pulled by
+    the covariance term). Returns a summary dict shaped like the shared lampe
+    trainer's summaries (so ensembling/plotting code is unchanged).
     """
     tt = estimator.theta_transform
     xt = estimator.x_transform
     rows = estimator._tril_rows
     cols = estimator._tril_cols
 
-    # ----- Stage 1: mean network (plain MSE against true theta) -----
-    def loss_mu(x, theta):
-        z = estimator.emb_mu(xt.inv(x).float())
-        mu = estimator.mu_net(z)
-        return F.mse_loss(mu, tt.inv(theta))
-
-    if verbose:
-        logging.info("Moment network: training Stage 1 (mean network).")
-    s1_train, s1_val, _ = _fit_stage(
-        [estimator.emb_mu, estimator.mu_net], loss_mu,
-        train_loader, val_loader, train_args, device,
-        desc='moment-mean', verbose=verbose)
-
-    # freeze Stage 1
-    for p in estimator.emb_mu.parameters():
-        p.requires_grad_(False)
-    for p in estimator.mu_net.parameters():
-        p.requires_grad_(False)
-    estimator.emb_mu.eval()
-    estimator.mu_net.eval()
-
-    # ----- Stage 2: covariance network (MSE toward residual products) -----
-    def loss_cov(x, theta):
+    def loss_fn(x, theta):
         xin = xt.inv(x).float()
-        with torch.no_grad():
-            mu = estimator.mu_net(estimator.emb_mu(xin))
-        resid = tt.inv(theta) - mu                       # frozen residuals
+        theta_n = tt.inv(theta)
+
+        mu = estimator.mu_net(estimator.emb_mu(xin))
+        term_mean = _logsum_sq(theta_n - mu)
+
+        resid = theta_n - mu.detach()                     # stop-gradient
         L = estimator._build_L(estimator.cov_net(estimator.emb_cov(xin)))
         Sigma = L @ L.transpose(-1, -2)
-        pred = Sigma[:, rows, cols]                      # vech(Sigma)
-        outer = resid.unsqueeze(-1) * resid.unsqueeze(-2)
-        target = outer[:, rows, cols]                    # vech(resid resid^T)
-        return F.mse_loss(pred, target)
+        pred = Sigma[:, rows, cols]                        # vech(Sigma)
+        target = (resid.unsqueeze(-1) * resid.unsqueeze(-2))[:, rows, cols]
+        term_cov = _logsum_sq(pred - target)
+
+        return term_mean + term_cov
 
     if verbose:
-        logging.info("Moment network: training Stage 2 (covariance network).")
-    s2_train, s2_val, _ = _fit_stage(
-        [estimator.emb_cov, estimator.cov_net], loss_cov,
-        train_loader, val_loader, train_args, device,
-        desc='moment-cov', verbose=verbose)
+        logging.info(
+            "Moment network: joint training of mean + covariance nets.")
+    train_trace, val_trace, _ = _fit_stage(
+        [estimator.emb_mu, estimator.mu_net,
+         estimator.emb_cov, estimator.cov_net],
+        loss_fn, train_loader, val_loader, train_args, device,
+        desc='moment', verbose=verbose)
 
     # ----- final validation log-prob (comparable to flow members) -----
     estimator.eval()
@@ -421,15 +445,9 @@ def train_moment_network(estimator: MomentNetworkEstimator,
         best_val_logprob = tot / cnt
 
     summary = {
-        # generic keys expected by ensembling / plotting code
-        'training_log_probs': [-v for v in (s1_train + s2_train)],
-        'validation_log_probs': [-v for v in (s1_val + s2_val)],
+        'training_log_probs': [-v for v in train_trace],
+        'validation_log_probs': [-v for v in val_trace],
         'best_validation_log_prob': best_val_logprob,
-        'epochs_trained': len(s1_val) + len(s2_val),
-        # moment-network specific diagnostics
-        'stage1_train_mse': s1_train,
-        'stage1_val_mse': s1_val,
-        'stage2_train_mse': s2_train,
-        'stage2_val_mse': s2_val,
+        'epochs_trained': len(val_trace),
     }
     return summary

--- a/ili/inference/lampe_moment.py
+++ b/ili/inference/lampe_moment.py
@@ -1,0 +1,435 @@
+"""
+Standalone two-stage trainer and estimator for Moment Networks
+(Jeffrey & Wandelt 2020, arXiv:2011.05991) in the lampe backend.
+
+A Moment Network does not learn a full joint density like the zuko flows that
+the lampe backend usually wraps. Instead it directly regresses the posterior
+mean and covariance:
+
+    Stage 1 (mean network):
+        f_mu(x) -> mu, trained with plain MSE against the true parameters theta.
+
+    Stage 2 (covariance network), trained *after* Stage 1 is frozen:
+        resid    = theta - f_mu(x)              # frozen, no gradient
+        target   = vech(resid resid^T)          # residual products, i<=j
+        f_cov(x) -> raw Cholesky entries -> L -> Sigma = L L^T
+        loss     = MSE(vech(Sigma), target)     # plain MSE
+
+    Because E[resid resid^T | x] = Sigma(x), minimizing the MSE between
+    vech(Sigma) and the residual-product targets drives L L^T towards the true
+    conditional covariance, while the Cholesky parameterization (lower
+    triangular, softplus on the diagonal) guarantees Sigma is positive-definite
+    by construction. This reconciles the reference implementation's
+    "regress toward residual products" targets with the requirement to output a
+    valid covariance.
+
+The resulting posterior is a single (full-covariance) Gaussian approximation.
+It is *not* a flexible density -- it is unimodal and Gaussian -- so on its own
+it can only capture Gaussian posteriors. It is most useful as one member of an
+ensemble alongside real flows (maf/nsf/...), where it is sampled and log_prob'd
+identically via a torch MultivariateNormal.
+
+This module is self-contained: the two-stage training lives entirely inside
+``train_moment_network``, and the trained ``MomentNetworkEstimator`` is a
+drop-in ensemble member (it subclasses ``LampeNPE`` to reuse its accept-reject
+sampling and device handling).
+"""
+
+import logging
+from copy import deepcopy
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributions import Distribution, MultivariateNormal
+from torch.distributions.transforms import (
+    identity_transform, AffineTransform)
+from sklearn.preprocessing import StandardScaler
+
+from ili.utils.ndes_pt import LampeNPE
+
+_ACTIVATIONS = {
+    'relu': nn.ReLU,
+    'tanh': nn.Tanh,
+    'elu': nn.ELU,
+    'gelu': nn.GELU,
+    'silu': nn.SiLU,
+    'leaky_relu': nn.LeakyReLU,
+}
+
+
+def _make_mlp(in_dim, out_dim, hidden_features, hidden_depth, activation):
+    """Build a simple MLP trunk with ``hidden_depth`` hidden layers."""
+    act = _ACTIVATIONS[activation]
+    layers, d = [], in_dim
+    for _ in range(hidden_depth):
+        layers += [nn.Linear(d, hidden_features), act()]
+        d = hidden_features
+    layers.append(nn.Linear(d, out_dim))
+    return nn.Sequential(*layers)
+
+
+class MomentNetworkEstimator(LampeNPE):
+    """A trained Moment Network posterior, interchangeable with lampe flows.
+
+    Predicts a full-covariance Gaussian posterior N(mu(x), Sigma(x)) with
+    Sigma = L L^T for a lower-triangular Cholesky factor L. Subclasses
+    ``LampeNPE`` so that ``sample`` (accept-reject within prior support),
+    ``to``, and the ensemble interface are inherited unchanged; only the
+    conditional distribution (``flow``) and ``forward`` (log_prob) are
+    overridden.
+
+    All internal networks operate in normalized theta/x space; the
+    ``theta_transform`` maps predictions back to physical parameter space
+    (matching how ``LampeNPE`` handles normalization).
+    """
+
+    is_moment = True
+
+    def __init__(
+        self,
+        emb_mu: nn.Module,
+        mu_net: nn.Module,
+        emb_cov: nn.Module,
+        cov_net: nn.Module,
+        n_params: int,
+        prior: Distribution,
+        x_transform=identity_transform,
+        theta_transform=identity_transform,
+    ):
+        nn.Module.__init__(self)
+        self.emb_mu = emb_mu
+        self.mu_net = mu_net
+        self.emb_cov = emb_cov
+        self.cov_net = cov_net
+        self.n_params = n_params
+        self.prior = prior
+        self.x_transform = x_transform
+        self.theta_transform = theta_transform
+        self._device = 'cpu'
+        self.max_sample_size = 1000
+
+        # lower-triangular (row-major, i>=j) index helpers, incl. diagonal
+        rows, cols = torch.tril_indices(n_params, n_params)
+        self.register_buffer('_tril_rows', rows)
+        self.register_buffer('_tril_cols', cols)
+        self.register_buffer('_is_diag', (rows == cols))
+
+    @property
+    def n_cov_outputs(self) -> int:
+        return self.n_params * (self.n_params + 1) // 2
+
+    def _build_L(self, raw: torch.Tensor) -> torch.Tensor:
+        """Map a flat (B, n(n+1)/2) network output to a valid Cholesky factor.
+
+        The diagonal entries are passed through a softplus (plus a small floor)
+        to guarantee strict positivity, so ``L @ L.T`` is always
+        positive-definite. Off-diagonal entries are used as-is.
+        """
+        B = raw.shape[0]
+        n = self.n_params
+        # softplus + floor on the diagonal entries only; leave off-diag as-is
+        vals = torch.where(
+            self._is_diag.unsqueeze(0),
+            F.softplus(raw) + 1e-6,
+            raw,
+        )
+        L = raw.new_zeros(B, n, n)
+        L[:, self._tril_rows, self._tril_cols] = vals
+        return L
+
+    def predict_moments(self, x):
+        """Return (mu, L) in normalized theta space for input data x.
+
+        mu has shape (B, n_params); L is a (B, n_params, n_params) lower-
+        triangular Cholesky factor with Sigma = L @ L.T.
+        """
+        if isinstance(x, (list, np.ndarray)):
+            x = torch.Tensor(x)
+        x = x.to(self._device)
+        xin = self.x_transform.inv(x).float()
+        mu = self.mu_net(self.emb_mu(xin))
+        L = self._build_L(self.cov_net(self.emb_cov(xin)))
+        return mu, L
+
+    def flow(self, x):  # -> Distribution (normalized theta space)
+        """Conditional posterior as a MultivariateNormal in normalized space."""
+        mu, L = self.predict_moments(x)
+        return MultivariateNormal(mu, scale_tril=L)
+
+    def forward(self, theta: torch.Tensor, x) -> torch.Tensor:
+        """Log-probability of theta under the Gaussian posterior given x.
+
+        Mirrors ``LampeNPE.forward``: evaluates in normalized theta space and
+        corrects by the theta_transform Jacobian, so it is directly comparable
+        to the other ensemble members' log-probabilities.
+        """
+        if isinstance(x, (list, np.ndarray)):
+            x = torch.Tensor(x)
+        if isinstance(theta, (list, np.ndarray)):
+            theta = torch.Tensor(theta)
+        x = x.to(self._device)
+        theta = theta.to(self._device)
+
+        logprob = self.flow(x).log_prob(self.theta_transform.inv(theta))
+        log_abs_det_jacobian = self.theta_transform.log_abs_det_jacobian(
+            theta, theta)  # constant for Affine/Identity; just for shape
+        if len(log_abs_det_jacobian.shape) > 1:
+            log_abs_det_jacobian = log_abs_det_jacobian.sum(dim=1)
+        return logprob - log_abs_det_jacobian
+
+    potential = forward
+
+    def log_prob(self, theta: torch.Tensor, x) -> torch.Tensor:
+        return self.forward(theta, x)
+
+
+class _Lampe_Moment_Constructor():
+    """Deferred builder for a Moment Network, mirroring ``_Lampe_Net_Constructor``.
+
+    Constructed by ``load_nde_lampe(model='moment', ...)`` and called later as
+    ``constructor(train_loader, prior)`` to build an (untrained)
+    ``MomentNetworkEstimator``. The actual two-stage fit is performed
+    separately by ``train_moment_network``; the runner detects this net via the
+    ``is_moment`` marker and routes it there.
+    """
+
+    is_moment = True
+
+    def __init__(self, embedding_net, model_args, device,
+                 x_normalize, theta_normalize):
+        self.embedding_net = embedding_net
+        self.model_args = model_args
+        self.device = device
+        self.x_normalize = x_normalize
+        self.theta_normalize = theta_normalize
+
+    def to(self, device):
+        self.device = device
+        return self
+
+    def _fit_transforms(self, train_loader, dtype):
+        """Compute z-normalization transforms over the training set."""
+        x_transform = identity_transform
+        theta_transform = identity_transform
+
+        if self.x_normalize:
+            scaler = StandardScaler()
+            for x_batch, _ in train_loader:
+                scaler.partial_fit(x_batch.cpu().numpy())
+            x_mean = torch.tensor(scaler.mean_, dtype=dtype).to(self.device)
+            x_std = torch.clamp(
+                torch.tensor(scaler.scale_, dtype=dtype).to(self.device),
+                min=1e-16)
+            x_transform = AffineTransform(loc=x_mean, scale=x_std, event_dim=1)
+
+        if self.theta_normalize:
+            scaler = StandardScaler()
+            for _, theta_batch in train_loader:
+                scaler.partial_fit(theta_batch.cpu().numpy())
+            theta_mean = torch.tensor(scaler.mean_, dtype=dtype).to(self.device)
+            theta_std = torch.clamp(
+                torch.tensor(scaler.scale_, dtype=dtype).to(self.device),
+                min=1e-16)
+            theta_transform = AffineTransform(
+                loc=theta_mean, scale=theta_std, event_dim=1)
+
+        return x_transform, theta_transform
+
+    def __call__(self, train_loader, prior) -> MomentNetworkEstimator:
+        # infer input/output dimensions from a batch
+        x_batch, theta_batch = next(iter(train_loader))
+        dtype = x_batch.dtype
+
+        # two independent embedding_net instances, one per stage (matches the
+        # reference's independently-initialized networks)
+        emb_mu = deepcopy(self.embedding_net).to(self.device)
+        emb_cov = deepcopy(self.embedding_net).to(self.device)
+
+        z_batch = emb_mu(x_batch.cpu())
+        z_shape = z_batch.shape[1:]
+        theta_shape = theta_batch.shape[1:]
+        if len(z_shape) > 1:
+            raise ValueError("Embedding network must return a vector.")
+        if len(theta_shape) > 1:
+            raise ValueError("Parameters theta must be a vector.")
+        z_dim = z_shape[0]
+        n_params = theta_shape[0]
+        n_cov = n_params * (n_params + 1) // 2
+
+        hidden_features = self.model_args['hidden_features']
+        hidden_depth = self.model_args['hidden_depth']
+        activation = self.model_args['activation']
+
+        mu_net = _make_mlp(
+            z_dim, n_params, hidden_features, hidden_depth, activation
+        ).to(self.device)
+        cov_net = _make_mlp(
+            z_dim, n_cov, hidden_features, hidden_depth, activation
+        ).to(self.device)
+
+        x_transform, theta_transform = self._fit_transforms(train_loader, dtype)
+
+        estimator = MomentNetworkEstimator(
+            emb_mu=emb_mu, mu_net=mu_net,
+            emb_cov=emb_cov, cov_net=cov_net,
+            n_params=n_params, prior=prior,
+            x_transform=x_transform, theta_transform=theta_transform,
+        ).to(self.device)
+        return estimator
+
+
+def _fit_stage(modules, loss_fn, train_loader, val_loader,
+               train_args, device, desc='', verbose=True):
+    """Train a set of modules to convergence via MSE with early stopping.
+
+    Generic single-stage optimizer loop, following the same early-stopping /
+    patience / lr conventions as the shared lampe trainer. Returns
+    (train_trace, val_trace, best_val_loss) and restores the best weights.
+    """
+    from tqdm import tqdm
+
+    params = [p for m in modules for p in m.parameters() if p.requires_grad]
+    optimizer = torch.optim.AdamW(
+        params, lr=train_args["learning_rate"],
+        weight_decay=train_args["weight_decay"])
+    clip = train_args["clip_max_norm"]
+    early_stopping = train_args.get("early_stopping", True)
+    max_epochs = int(train_args["max_epochs"])
+
+    best_val = float('inf')
+    best_state = [deepcopy(m.state_dict()) for m in modules]
+    wait = 0
+    train_trace, val_trace = [], []
+
+    with tqdm(range(max_epochs), unit=' epochs', disable=not verbose,
+              desc=desc) as tq:
+        for epoch in tq:
+            for m in modules:
+                m.train()
+            tot, cnt = 0.0, 0
+            for x, theta in train_loader:
+                x, theta = x.to(device), theta.to(device)
+                optimizer.zero_grad()
+                loss = loss_fn(x, theta)
+                loss.backward()
+                if clip:
+                    nn.utils.clip_grad_norm_(params, clip)
+                optimizer.step()
+                tot += loss.item() * len(theta)
+                cnt += len(theta)
+            train_loss = tot / cnt
+
+            for m in modules:
+                m.eval()
+            with torch.no_grad():
+                tot, cnt = 0.0, 0
+                for x, theta in val_loader:
+                    x, theta = x.to(device), theta.to(device)
+                    tot += loss_fn(x, theta).item() * len(theta)
+                    cnt += len(theta)
+                val_loss = tot / cnt
+
+            train_trace.append(train_loss)
+            val_trace.append(val_loss)
+            tq.set_postfix(mse=train_loss, mse_val=val_loss)
+
+            if val_loss < best_val:
+                best_val = val_loss
+                best_state = [deepcopy(m.state_dict()) for m in modules]
+                wait = 0
+            elif early_stopping:
+                if wait > train_args["stop_after_epochs"]:
+                    break
+                wait += 1
+        else:
+            if early_stopping:
+                logging.warning(
+                    f"Moment network stage '{desc}' did not converge in "
+                    f"{max_epochs} epochs.")
+
+    for m, s in zip(modules, best_state):
+        m.load_state_dict(s)
+    return train_trace, val_trace, best_val
+
+
+def train_moment_network(estimator: MomentNetworkEstimator,
+                         train_loader, val_loader,
+                         train_args, device, verbose=True):
+    """Run the two-stage Moment Network fit in place on ``estimator``.
+
+    Stage 1 fits the mean network with MSE against theta. Stage 2 freezes it,
+    derives residual-product targets, and fits the covariance network so that
+    vech(L L^T) matches those targets. Returns a summary dict shaped like the
+    shared lampe trainer's summaries (so ensembling/plotting code is unchanged).
+    """
+    tt = estimator.theta_transform
+    xt = estimator.x_transform
+    rows = estimator._tril_rows
+    cols = estimator._tril_cols
+
+    # ----- Stage 1: mean network (plain MSE against true theta) -----
+    def loss_mu(x, theta):
+        z = estimator.emb_mu(xt.inv(x).float())
+        mu = estimator.mu_net(z)
+        return F.mse_loss(mu, tt.inv(theta))
+
+    if verbose:
+        logging.info("Moment network: training Stage 1 (mean network).")
+    s1_train, s1_val, _ = _fit_stage(
+        [estimator.emb_mu, estimator.mu_net], loss_mu,
+        train_loader, val_loader, train_args, device,
+        desc='moment-mean', verbose=verbose)
+
+    # freeze Stage 1
+    for p in estimator.emb_mu.parameters():
+        p.requires_grad_(False)
+    for p in estimator.mu_net.parameters():
+        p.requires_grad_(False)
+    estimator.emb_mu.eval()
+    estimator.mu_net.eval()
+
+    # ----- Stage 2: covariance network (MSE toward residual products) -----
+    def loss_cov(x, theta):
+        xin = xt.inv(x).float()
+        with torch.no_grad():
+            mu = estimator.mu_net(estimator.emb_mu(xin))
+        resid = tt.inv(theta) - mu                       # frozen residuals
+        L = estimator._build_L(estimator.cov_net(estimator.emb_cov(xin)))
+        Sigma = L @ L.transpose(-1, -2)
+        pred = Sigma[:, rows, cols]                      # vech(Sigma)
+        outer = resid.unsqueeze(-1) * resid.unsqueeze(-2)
+        target = outer[:, rows, cols]                    # vech(resid resid^T)
+        return F.mse_loss(pred, target)
+
+    if verbose:
+        logging.info("Moment network: training Stage 2 (covariance network).")
+    s2_train, s2_val, _ = _fit_stage(
+        [estimator.emb_cov, estimator.cov_net], loss_cov,
+        train_loader, val_loader, train_args, device,
+        desc='moment-cov', verbose=verbose)
+
+    # ----- final validation log-prob (comparable to flow members) -----
+    estimator.eval()
+    with torch.no_grad():
+        tot, cnt = 0.0, 0
+        for x, theta in val_loader:
+            x, theta = x.to(device), theta.to(device)
+            tot += estimator.log_prob(theta, x).sum().item()
+            cnt += len(theta)
+        best_val_logprob = tot / cnt
+
+    summary = {
+        # generic keys expected by ensembling / plotting code
+        'training_log_probs': [-v for v in (s1_train + s2_train)],
+        'validation_log_probs': [-v for v in (s1_val + s2_val)],
+        'best_validation_log_prob': best_val_logprob,
+        'epochs_trained': len(s1_val) + len(s2_val),
+        # moment-network specific diagnostics
+        'stage1_train_mse': s1_train,
+        'stage1_val_mse': s1_val,
+        'stage2_train_mse': s2_train,
+        'stage2_val_mse': s2_val,
+    }
+    return summary

--- a/ili/inference/runner_lampe.py
+++ b/ili/inference/runner_lampe.py
@@ -181,11 +181,37 @@ class LampeRunner():
             signatures=signatures,
         )
 
+    def _add_training_noise(self, train_loader: DataLoader) -> DataLoader:
+        """Wrap a pre-built training DataLoader's dataset with Gaussian noise
+        (a percentage of each tensor's per-feature std), per
+        ``train_args['noise_percent']``.
+
+        Loaders built directly from tensors (e.g. via ``TorchLoader``) skip
+        the ``NoisyDataset`` wrapping that ``_prepare_loader`` otherwise
+        applies for ``get_all_data``-style loaders, so without this
+        ``noise_percent`` would silently do nothing for them.
+        """
+        percentage = self.train_args["noise_percent"]
+        if not percentage:
+            return train_loader
+        if not isinstance(train_loader.dataset, TensorDataset):
+            logging.warning(
+                "noise_percent > 0 but the training DataLoader's dataset "
+                "isn't a TensorDataset; cannot apply noise augmentation.")
+            return train_loader
+        shuffle = isinstance(train_loader.sampler, torch.utils.data.RandomSampler)
+        noisy_dataset = NoisyDataset(
+            *train_loader.dataset.tensors, percentage=percentage)
+        return DataLoader(
+            noisy_dataset, batch_size=train_loader.batch_size,
+            shuffle=shuffle)
+
     def _prepare_loader(self, loader: _BaseLoader):
         """Prepare a loader for training."""
         if (hasattr(loader, "train_loader") and
                 hasattr(loader, "val_loader")):
             train_loader, val_loader = loader.train_loader, loader.val_loader
+            train_loader = self._add_training_noise(train_loader)
         elif (hasattr(loader, "get_all_data") and
                 hasattr(loader, "get_all_parameters")):
             x, theta = loader.get_all_data(), loader.get_all_parameters()
@@ -277,10 +303,10 @@ class LampeRunner():
             if verbose:
                 logging.info(f"Training model {i+1} / {len(models_rnd)}.")
 
-            # Moment Networks use a bespoke two-stage (mean, then covariance)
-            # training procedure that does not fit the shared NPE optimizer
-            # loop below. Dispatch them to their standalone trainer; the
-            # returned estimator is a drop-in ensemble member.
+            # Moment Networks use a bespoke joint (mean + covariance) training
+            # procedure that does not fit the shared NPE optimizer loop below.
+            # Dispatch them to their standalone trainer; the returned
+            # estimator is a drop-in ensemble member.
             if getattr(model, 'is_moment', False):
                 from ili.inference.lampe_moment import train_moment_network
                 summary = train_moment_network(

--- a/ili/inference/runner_lampe.py
+++ b/ili/inference/runner_lampe.py
@@ -277,6 +277,19 @@ class LampeRunner():
             if verbose:
                 logging.info(f"Training model {i+1} / {len(models_rnd)}.")
 
+            # Moment Networks use a bespoke two-stage (mean, then covariance)
+            # training procedure that does not fit the shared NPE optimizer
+            # loop below. Dispatch them to their standalone trainer; the
+            # returned estimator is a drop-in ensemble member.
+            if getattr(model, 'is_moment', False):
+                from ili.inference.lampe_moment import train_moment_network
+                summary = train_moment_network(
+                    model, train_loader, val_loader,
+                    self.train_args, self.device, verbose=verbose)
+                posteriors.append(model)
+                summaries.append(summary)
+                continue
+
             # define optimizer
             optimizer = torch.optim.AdamW(
                 model.parameters(),

--- a/ili/utils/__init__.py
+++ b/ili/utils/__init__.py
@@ -11,7 +11,7 @@ try:
         IndependentLogNormal, IndependentPareto, IndependentStudentT,
         IndependentVonMises, IndependentWeibull,
         MultivariateNormal, LowRankMultivariateNormal,
-        IndependentTruncatedNormal
+        IndependentTruncatedNormal, CustomJointIndependent
     )
     from .ndes_pt import load_nde_sbi, load_nde_lampe, LampeNPE, LampeEnsemble
     loaded = True

--- a/ili/utils/distributions_pt.py
+++ b/ili/utils/distributions_pt.py
@@ -291,7 +291,7 @@ class CustomJointIndependent(Distribution):
         return self._support
 
     def sample(self, sample_shape=torch.Size()):
-        return torch.concatenate(
+        return torch.stack(
             [d.sample(sample_shape) for d in self.distributions], dim=-1)
 
     def rsample(self, sample_shape=torch.Size()):
@@ -299,7 +299,7 @@ class CustomJointIndependent(Distribution):
                    for d in self.distributions):
             raise NotImplementedError(
                 "At least one component does not support rsample().")
-        return torch.concatenate(
+        return torch.stack(
             [d.rsample(sample_shape) for d in self.distributions], dim=-1)
 
     def log_prob(self, value):

--- a/ili/utils/ndes_pt.py
+++ b/ili/utils/ndes_pt.py
@@ -300,6 +300,10 @@ def load_nde_lampe(
         - sospf: Sum-of-Squares Polynomial Flow (https://arxiv.org/abs/1905.02325)
         - naf: Neural Autoregressive Flow (https://arxiv.org/abs/1804.00779)
         - unaf: Unconstrained Neural Autoregressive Flow (https://arxiv.org/abs/1908.05164)
+        - moment: Moment Network (https://arxiv.org/abs/2011.05991). Not a flow;
+            approximates the posterior as a single full-covariance Gaussian via
+            an internal two-stage (mean, then covariance) training procedure.
+            Accepts hidden_features, hidden_depth, activation, embedding_net.
 
     For more info, see zuko at https://zuko.readthedocs.io/en/stable/index.html
 
@@ -323,6 +327,40 @@ def load_nde_lampe(
             'You probably meant to specify engine="NPE" or to use the NLE or NRE'
             ' engines in the sbi or pydelfi backends.')
     model = model.lower()
+
+    # Moment Networks (Jeffrey & Wandelt 2020) have a bespoke two-stage
+    # training path and are built by a separate constructor. They are lampe-only
+    # NPE models that approximate the posterior as a full-covariance Gaussian.
+    if model == 'moment':
+        from ili.inference.lampe_moment import _Lampe_Moment_Constructor
+        moment_defaults = dict(
+            hidden_features=64, hidden_depth=3, activation='relu')
+        extra = set(model_args.keys()) - set(moment_defaults.keys())
+        # warn (don't error) on flow-specific kwargs that don't apply here
+        for k in ('num_transforms', 'num_components'):
+            if k in extra:
+                logging.warning(
+                    f"Argument '{k}' does not apply to model 'moment' and "
+                    "will be ignored.")
+                extra.discard(k)
+                model_args.pop(k)
+        if extra:
+            raise ValueError(
+                f"Model moment arguments mispecified. Extra arguments found: "
+                f"{extra}.")
+        if 'activation' in model_args and \
+                model_args['activation'] not in (
+                    'relu', 'tanh', 'elu', 'gelu', 'silu', 'leaky_relu'):
+            raise ValueError(
+                f"Unknown activation '{model_args['activation']}' for model "
+                "'moment'.")
+        moment_args = {**moment_defaults, **model_args}
+        embedding_net = deepcopy(embedding_net)
+        return [
+            _Lampe_Moment_Constructor(
+                embedding_net, moment_args, device,
+                x_normalize, theta_normalize) for _ in range(repeats)
+        ]
 
     # check the model parameterizations
     if model == 'mdn':

--- a/ili/utils/ndes_pt.py
+++ b/ili/utils/ndes_pt.py
@@ -48,9 +48,9 @@ def load_nde_sbi(
     """Load an nde from sbi.
 
     Args:
-        engine (str): engine to use. 
+        engine (str): engine to use.
             One of: NPE, NLE, NRE, SNPE, SNLE, or SNRE.
-        model (str): model to use. 
+        model (str): model to use.
             One of: mdn, maf, nsf, made, linear, mlp, resnet.
         embedding_net (nn.Module, optional): embedding network to use.
             Defaults to nn.Identity().
@@ -170,16 +170,13 @@ class LampeNPE(nn.Module):
         x: torch.Tensor,
         show_progress_bars: bool = True
     ) -> torch.Tensor:
-        """Accept-reject sampling"""
         if isinstance(shape, int):
             shape = (shape,)
 
-        # check inputs
         if isinstance(x, (list, np.ndarray)):
             x = torch.Tensor(x)
         x = x.to(self._device)
 
-        # sample
         num_samples = np.prod(shape)
         if num_samples == 0:
             return torch.empty(shape)
@@ -193,23 +190,42 @@ class LampeNPE(nn.Module):
         num_remaining = num_samples
         accepted = []
         tries = 0
+        total_drawn = 0
+        total_accepted = 0
         while num_remaining > 0:
             candidates = self.theta_transform(
                 self.flow(x).sample((batch_size,)))
-            are_accepted = self.prior.support.check(candidates)
+
+            # Check if the dimensions have been reduced by the prior
+            raw_check = self.prior.support.check(candidates)
+            if raw_check.dim() == candidates.dim():
+                are_accepted = raw_check.all(dim=-1)
+            else:
+                are_accepted = raw_check
             samples = candidates[are_accepted]
             accepted.append(samples)
 
             num_remaining -= len(samples)
             pbar.update(len(samples))
             tries += 1
-            if tries > 10*len(samples)/batch_size:  # 10x the expected number of tries
+            drawn_this_loop = are_accepted.numel()
+            total_drawn += drawn_this_loop
+            total_accepted += len(samples)
+
+            rate = total_accepted / total_drawn
+            expected_tries = num_samples / max(rate * drawn_this_loop, 1e-12)
+            max_tries = max(1000, 10 * int(np.ceil(num_samples / batch_size)))
+
+            if tries > 10 * expected_tries or tries > max_tries:
                 warnings.warn(
                     "Direct sampling took too long. The posterior is poorly "
-                    "constrained within the prior support. Consider using "
-                    "emcee sampling or using a larger prior support. Returning"
-                    " prior samples.")
+                    "constrained within the prior support (measured "
+                    f"acceptance rate: {rate:.4%}, over {total_drawn} "
+                    "candidates drawn). Consider using emcee sampling or "
+                    "using a larger prior support. Returning prior samples."
+                )
                 return self.prior.sample(shape)
+
         pbar.close()
 
         samples = torch.cat(accepted, dim=0)[:num_samples]
@@ -302,8 +318,11 @@ def load_nde_lampe(
         - unaf: Unconstrained Neural Autoregressive Flow (https://arxiv.org/abs/1908.05164)
         - moment: Moment Network (https://arxiv.org/abs/2011.05991). Not a flow;
             approximates the posterior as a single full-covariance Gaussian via
-            an internal two-stage (mean, then covariance) training procedure.
-            Accepts hidden_features, hidden_depth, activation, embedding_net.
+            an internal joint (mean + covariance) training procedure.
+            Its own trunk is a constant-width MLP, configured like mdn:
+            hidden_features, hidden_depth, activation. Any funnel-shaped
+            compression belongs in embedding_net (e.g. embedding_net='fun'),
+            not in this model's own architecture args.
 
     For more info, see zuko at https://zuko.readthedocs.io/en/stable/index.html
 
@@ -328,8 +347,8 @@ def load_nde_lampe(
             ' engines in the sbi or pydelfi backends.')
     model = model.lower()
 
-    # Moment Networks (Jeffrey & Wandelt 2020) have a bespoke two-stage
-    # training path and are built by a separate constructor. They are lampe-only
+    # Moment Networks (Jeffrey & Wandelt 2020) have a bespoke joint training
+    # path and are built by a separate constructor. They are lampe-only
     # NPE models that approximate the posterior as a full-covariance Gaussian.
     if model == 'moment':
         from ili.inference.lampe_moment import _Lampe_Moment_Constructor


### PR DESCRIPTION
## Summary
Adds `model='moment'` (Jeffrey & Wandelt 2020, [arXiv:2011.05991](https://arxiv.org/abs/2011.05991)) to the lampe backend — approximates `p(theta|x)` as a single Gaussian `N(mu(x), Sigma(x))`, useful as a fast ensemble member alongside real flows. Plus three bug fixes in shared code, surfaced while integrating and testing it.

## Commits
1. **Add moment network** — `MomentNetworkEstimator` (Cholesky-parameterized covariance, `LampeNPE` subclass) + trainer, dispatched from `runner_lampe.py` via an `is_moment` marker.
2. **Fix `CustomJointIndependent.sample`/`rsample`** — used `concatenate` instead of `stack` on per-dimension scalar distributions, producing a wrong-shaped flat tensor. Pre-existing bug, no exercised caller until now.
3. **Fix `TorchLoader` noise** — `LampeRunner._prepare_loader`'s `TorchLoader` branch never applied `noise_percent`. **Not moment-specific** — any caller building its own loaders was silently training without augmentation.
4. **Rewrite moment training to joint, not two-stage** — mean and covariance nets now update together each batch (`logsum_sq` loss instead of plain MSE, stop-gradient on the covariance target so it doesn't pull the mean). Also added `lr_scheduler` support to its optimizer loop, previously read from config but never used.
5. **Fix accept-reject give-up logic** — `LampeNPE.sample()` judged acceptance rate from only the last batch (noisy, can spuriously read 0) and never scaled its threshold with `num_samples`. Now tracks a cumulative rate and scales properly, with an absolute `max_tries` backstop so genuine ~0%-acceptance cases still terminate. **Shared code — affects every flow's `sample()`, not just moment.**

## Testing
No unit tests added. Verified manually (training convergence, `CustomJointIndependent` shapes, accept-reject across good/near-perfect/~0% acceptance regimes, noise-loader effect) via uncommitted scripts — recommend adding real tests before/after merge.

## Backward compatibility
Fixes 2, 3, 5 touch shared paths used by every existing model, not just moment. In particular, any run using `TorchLoader` with `noise_percent > 0` will now actually get augmentation it wasn't getting before — retraining with an unchanged config may shift results.
